### PR TITLE
[MOB-17672] Use event type/source from core

### DIFF
--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/CompletionHandlerFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/CompletionHandlerFunctionalTests.java
@@ -54,10 +54,10 @@ public class CompletionHandlerFunctionalTests {
 
 	@Before
 	public void setup() throws Exception {
-		setExpectationEvent(EventType.HUB.getName(), EventSource.BOOTED.getName(), 1);
-		setExpectationEvent(EventType.CONFIGURATION.getName(), EventSource.REQUEST_CONTENT.getName(), 1);
-		setExpectationEvent(EventType.CONFIGURATION.getName(), EventSource.RESPONSE_CONTENT.getName(), 1);
-		setExpectationEvent(EventType.HUB.getName(), EventSource.SHARED_STATE.getName(), 4);
+		setExpectationEvent(EventType.HUB, EventSource.BOOTED, 1);
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.REQUEST_CONTENT, 1);
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT, 1);
+		setExpectationEvent(EventType.HUB, EventSource.SHARED_STATE, 4);
 
 		HashMap<String, Object> config = new HashMap<String, Object>() {
 			{

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/ConsentStatusChangeFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/ConsentStatusChangeFunctionalTests.java
@@ -51,12 +51,12 @@ public class ConsentStatusChangeFunctionalTests {
 
 	@Before
 	public void setup() throws Exception {
-		setExpectationEvent(EventType.HUB.getName(), EventSource.BOOTED.getName(), 1);
-		setExpectationEvent(EventType.CONFIGURATION.getName(), EventSource.REQUEST_CONTENT.getName(), 1);
-		setExpectationEvent(EventType.CONFIGURATION.getName(), EventSource.RESPONSE_CONTENT.getName(), 1);
+		setExpectationEvent(EventType.HUB, EventSource.BOOTED, 1);
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.REQUEST_CONTENT, 1);
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT, 1);
 
 		// hub shared state update for 4 extensions Edge, Config, Identity, Hub)
-		setExpectationEvent(EventType.HUB.getName(), EventSource.SHARED_STATE.getName(), 4);
+		setExpectationEvent(EventType.HUB, EventSource.SHARED_STATE, 4);
 
 		HashMap<String, Object> config = new HashMap<String, Object>() {
 			{

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
@@ -70,10 +70,10 @@ public class EdgeFunctionalTests {
 
 	@Before
 	public void setup() throws Exception {
-		setExpectationEvent(EventType.HUB.getName(), EventSource.BOOTED.getName(), 1);
-		setExpectationEvent(EventType.CONFIGURATION.getName(), EventSource.REQUEST_CONTENT.getName(), 1);
-		setExpectationEvent(EventType.CONFIGURATION.getName(), EventSource.RESPONSE_CONTENT.getName(), 1);
-		setExpectationEvent(EventType.HUB.getName(), EventSource.SHARED_STATE.getName(), 4);
+		setExpectationEvent(EventType.HUB, EventSource.BOOTED, 1);
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.REQUEST_CONTENT, 1);
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT, 1);
+		setExpectationEvent(EventType.HUB, EventSource.SHARED_STATE, 4);
 
 		HashMap<String, Object> config = new HashMap<String, Object>() {
 			{

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
@@ -107,11 +107,7 @@ public class EdgeFunctionalTests {
 
 	@Test
 	public void testSendEvent_withXDMData_sendsCorrectRequestEvent() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.REQUEST_CONTENT, 1);
 
 		ExperienceEvent experienceEvent = new ExperienceEvent.Builder()
 			.setXdmSchema(
@@ -146,10 +142,7 @@ public class EdgeFunctionalTests {
 
 		// verify
 		assertExpectedEvents(false);
-		List<Event> resultEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT
-		);
+		List<Event> resultEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.REQUEST_CONTENT);
 		assertEquals(1, resultEvents.size());
 		Map<String, Object> eventData = resultEvents.get(0).getEventData();
 		assertNotNull(eventData);
@@ -167,11 +160,7 @@ public class EdgeFunctionalTests {
 
 	@Test
 	public void testSendEvent_withXDMDataAndCustomData_sendsCorrectRequestEvent() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.REQUEST_CONTENT, 1);
 
 		ExperienceEvent experienceEvent = new ExperienceEvent.Builder()
 			.setXdmSchema(
@@ -213,10 +202,7 @@ public class EdgeFunctionalTests {
 
 		// verify
 		assertExpectedEvents(false);
-		List<Event> resultEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT
-		);
+		List<Event> resultEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.REQUEST_CONTENT);
 		assertEquals(1, resultEvents.size());
 		Map<String, Object> eventData = resultEvents.get(0).getEventData();
 		assertNotNull(eventData);
@@ -235,11 +221,7 @@ public class EdgeFunctionalTests {
 
 	@Test
 	public void testSendEvent_withXDMDataAndNullData_sendsCorrectRequestEvent() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.REQUEST_CONTENT, 1);
 
 		ExperienceEvent experienceEvent = new ExperienceEvent.Builder()
 			.setXdmSchema(
@@ -255,10 +237,7 @@ public class EdgeFunctionalTests {
 
 		// verify
 		assertExpectedEvents(false);
-		List<Event> resultEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT
-		);
+		List<Event> resultEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.REQUEST_CONTENT);
 		assertEquals(1, resultEvents.size());
 		Map<String, Object> eventData = resultEvents.get(0).getEventData();
 		assertNotNull(eventData);
@@ -726,7 +705,7 @@ public class EdgeFunctionalTests {
 			"\u0000{\"requestId\": \"0000-4a4e-1111-bf5c-abcd\",\"handle\": [{\"payload\": [{\"key\": \"kndctr_testOrg_AdobeOrg_identity\",\"value\": \"hashed_value\",\"maxAge\": 34128000},{\"key\": \"kndctr_testOrg_AdobeOrg_consent_check\",\"value\": \"1\",\"maxAge\": 7200},{\"key\": \"expired_key\",\"value\": \"1\",\"maxAge\": 0}],\"type\": \"state:store\"}]}\n";
 		HttpConnecting responseConnection = createNetworkResponse(storeResponseBody, 200);
 		setNetworkResponseFor(EXEDGE_INTERACT_URL_STRING, POST, responseConnection);
-		setExpectationEvent(FunctionalTestConstants.EventType.EDGE, "state:store", 1);
+		setExpectationEvent(EventType.EDGE, "state:store", 1);
 
 		Edge.sendEvent(XDM_EXPERIENCE_EVENT, null);
 
@@ -746,7 +725,7 @@ public class EdgeFunctionalTests {
 		// send a new event, should contain previously stored store data
 		setExpectationNetworkRequest(EXEDGE_INTERACT_URL_STRING, POST, 1);
 		setNetworkResponseFor(EXEDGE_INTERACT_URL_STRING, POST, responseConnection);
-		setExpectationEvent(FunctionalTestConstants.EventType.EDGE, "state:store", 1);
+		setExpectationEvent(EventType.EDGE, "state:store", 1);
 		Edge.sendEvent(XDM_EXPERIENCE_EVENT, null);
 
 		resultRequests = getNetworkRequestsWith(EXEDGE_INTERACT_URL_STRING, POST, TIMEOUT_MILLIS);
@@ -786,11 +765,7 @@ public class EdgeFunctionalTests {
 		setExpectationNetworkRequest(EXEDGE_INTERACT_URL_STRING, POST, 1);
 
 		// send the reset event before
-		final Event resetEvent = new Event.Builder(
-			"resetEvent",
-			EdgeConstants.EventType.EDGE_IDENTITY,
-			EdgeConstants.EventSource.RESET_COMPLETE
-		)
+		final Event resetEvent = new Event.Builder("resetEvent", EventType.EDGE_IDENTITY, EventSource.RESET_COMPLETE)
 			.build();
 		MobileCore.dispatchEvent(resetEvent, null);
 
@@ -798,7 +773,7 @@ public class EdgeFunctionalTests {
 			"\u0000{\"requestId\": \"0000-4a4e-1111-bf5c-abcd\",\"handle\": [{\"payload\": [{\"key\": \"kndctr_testOrg_AdobeOrg_identity\",\"value\": \"hashed_value\",\"maxAge\": 34128000},{\"key\": \"kndctr_testOrg_AdobeOrg_consent_check\",\"value\": \"1\",\"maxAge\": 7200},{\"key\": \"expired_key\",\"value\": \"1\",\"maxAge\": 0}],\"type\": \"state:store\"}]}\n";
 		HttpConnecting responseConnection = createNetworkResponse(storeResponseBody, 200);
 		setNetworkResponseFor(EXEDGE_INTERACT_URL_STRING, POST, responseConnection);
-		setExpectationEvent(FunctionalTestConstants.EventType.EDGE, "state:store", 1);
+		setExpectationEvent(EventType.EDGE, "state:store", 1);
 
 		Edge.sendEvent(XDM_EXPERIENCE_EVENT, null);
 
@@ -818,7 +793,7 @@ public class EdgeFunctionalTests {
 		// send a new event, should contain previously stored store data
 		setExpectationNetworkRequest(EXEDGE_INTERACT_URL_STRING, POST, 1);
 		setNetworkResponseFor(EXEDGE_INTERACT_URL_STRING, POST, responseConnection);
-		setExpectationEvent(FunctionalTestConstants.EventType.EDGE, "state:store", 1);
+		setExpectationEvent(EventType.EDGE, "state:store", 1);
 		Edge.sendEvent(XDM_EXPERIENCE_EVENT, null);
 
 		resultRequests = getNetworkRequestsWith(EXEDGE_INTERACT_URL_STRING, POST, TIMEOUT_MILLIS);
@@ -860,7 +835,7 @@ public class EdgeFunctionalTests {
 			"\u0000{\"requestId\": \"0000-4a4e-1111-bf5c-abcd\",\"handle\": [{\"payload\": [{\"key\": \"kndctr_testOrg_AdobeOrg_identity\",\"value\": \"hashed_value\",\"maxAge\": 34128000},{\"key\": \"kndctr_testOrg_AdobeOrg_consent_check\",\"value\": \"1\",\"maxAge\": 7200},{\"key\": \"expired_key\",\"value\": \"1\",\"maxAge\": 0}],\"type\": \"state:store\"}]}\n";
 		HttpConnecting responseConnection = createNetworkResponse(storeResponseBody, 200);
 		setNetworkResponseFor(EXEDGE_INTERACT_URL_STRING, POST, responseConnection);
-		setExpectationEvent(FunctionalTestConstants.EventType.EDGE, "state:store", 1);
+		setExpectationEvent(EventType.EDGE, "state:store", 1);
 
 		Edge.sendEvent(XDM_EXPERIENCE_EVENT, null);
 
@@ -878,18 +853,14 @@ public class EdgeFunctionalTests {
 		resetTestExpectations();
 
 		// send the reset event in-between
-		final Event resetEvent = new Event.Builder(
-			"resetEvent",
-			EdgeConstants.EventType.EDGE_IDENTITY,
-			EdgeConstants.EventSource.RESET_COMPLETE
-		)
+		final Event resetEvent = new Event.Builder("resetEvent", EventType.EDGE_IDENTITY, EventSource.RESET_COMPLETE)
 			.build();
 		MobileCore.dispatchEvent(resetEvent, null);
 
 		// send a new event, should contain previously stored store data
 		setExpectationNetworkRequest(EXEDGE_INTERACT_URL_STRING, POST, 1);
 		setNetworkResponseFor(EXEDGE_INTERACT_URL_STRING, POST, responseConnection);
-		setExpectationEvent(FunctionalTestConstants.EventType.EDGE, "state:store", 1);
+		setExpectationEvent(EventType.EDGE, "state:store", 1);
 		Edge.sendEvent(XDM_EXPERIENCE_EVENT, null);
 
 		resultRequests = getNetworkRequestsWith(EXEDGE_INTERACT_URL_STRING, POST, TIMEOUT_MILLIS);
@@ -908,12 +879,8 @@ public class EdgeFunctionalTests {
 	@Test
 	public void testSendEvent_receivesResponseEventHandle_sendsResponseEvent_pairedWithTheRequestEventId()
 		throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT,
-			1
-		);
-		setExpectationEvent(FunctionalTestConstants.EventType.EDGE, "personalization:decisions", 1);
+		setExpectationEvent(EventType.EDGE, EventSource.REQUEST_CONTENT, 1);
+		setExpectationEvent(EventType.EDGE, "personalization:decisions", 1);
 
 		final String responseBody =
 			"\u0000{\"requestId\": \"0ee43289-4a4e-469a-bf5c-1d8186919a26\",\"handle\": [{\"payload\": [{\"id\": \"AT:eyJhY3Rpdml0eUlkIjoiMTE3NTg4IiwiZXhwZXJpZW5jZUlkIjoiMSJ9\",\"scope\": \"buttonColor\",\"items\": [{                           \"schema\": \"https://ns.adobe.com/personalization/json-content-item\",\"data\": {\"content\": {\"value\": \"#D41DBA\"}}}]}],\"type\": \"personalization:decisions\",\"eventIndex\": 0}]}\n";
@@ -934,17 +901,11 @@ public class EdgeFunctionalTests {
 		assertEquals(1, resultRequests.size());
 		String requestId = resultRequests.get(0).queryParam("requestId");
 
-		List<Event> requestEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT
-		);
+		List<Event> requestEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.REQUEST_CONTENT);
 		assertEquals(1, requestEvents.size());
 		String requestEventUuid = requestEvents.get(0).getUniqueIdentifier();
 
-		List<Event> responseEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			"personalization:decisions"
-		);
+		List<Event> responseEvents = getDispatchedEventsWith(EventType.EDGE, "personalization:decisions");
 		assertEquals(1, responseEvents.size());
 		Map<String, Object> responseEventData = responseEvents.get(0).getEventData();
 		assertNotNull(responseEventData);
@@ -969,16 +930,8 @@ public class EdgeFunctionalTests {
 	@Test
 	public void testSendEvent_receivesResponseEventWarning_sendsErrorResponseEvent_pairedWithTheRequestEventId()
 		throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT,
-			1
-		);
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.REQUEST_CONTENT, 1);
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
 
 		final String responseBody =
 			"\u0000{\"requestId\": \"0ee43289-4a4e-469a-bf5c-1d8186919a26\",\"handle\": [],\"warnings\": [{\"eventIndex\": 0,\"code\": \"personalization:0\",\"message\": \"Failed due to unrecoverable system error\"}]}\n";
@@ -1009,17 +962,11 @@ public class EdgeFunctionalTests {
 		assertEquals(1, resultRequests.size());
 		String requestId = resultRequests.get(0).queryParam("requestId");
 
-		List<Event> requestEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT
-		);
+		List<Event> requestEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.REQUEST_CONTENT);
 		assertEquals(1, requestEvents.size());
 		String requestEventUuid = requestEvents.get(0).getUniqueIdentifier();
 
-		List<Event> errorResponseEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT
-		);
+		List<Event> errorResponseEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(1, errorResponseEvents.size());
 		Map<String, Object> responseEventData = errorResponseEvents.get(0).getEventData();
 		assertNotNull(responseEventData);
@@ -1048,7 +995,7 @@ public class EdgeFunctionalTests {
 		setExpectationNetworkRequest(EXEDGE_INTERACT_URL_STRING, POST, 1);
 		setExpectationNetworkRequest(EXEDGE_INTERACT_OR2_LOC_URL_STRING, POST, 1);
 
-		setExpectationEvent(FunctionalTestConstants.EventType.EDGE, "locationHint:result", 1);
+		setExpectationEvent(EventType.EDGE, "locationHint:result", 1);
 
 		Edge.sendEvent(XDM_EXPERIENCE_EVENT, null);
 		Edge.sendEvent(XDM_EXPERIENCE_EVENT, null);
@@ -1079,7 +1026,7 @@ public class EdgeFunctionalTests {
 		setNetworkResponseFor(EXEDGE_INTERACT_URL_STRING, POST, responseConnection);
 		setExpectationNetworkRequest(EXEDGE_INTERACT_URL_STRING, POST, 2);
 
-		setExpectationEvent(FunctionalTestConstants.EventType.EDGE, "locationHint:result", 1);
+		setExpectationEvent(EventType.EDGE, "locationHint:result", 1);
 
 		Edge.sendEvent(XDM_EXPERIENCE_EVENT, null);
 		Thread.sleep(1500); // wait for hint to expire
@@ -1382,11 +1329,7 @@ public class EdgeFunctionalTests {
 		responseConnection = createNetworkResponse(edgeResponse, 200);
 		setExpectationNetworkRequest(EXEDGE_INTERACT_URL_STRING, POST, 1);
 		setNetworkResponseFor(EXEDGE_INTERACT_URL_STRING, POST, responseConnection);
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
 
 		assertNetworkRequestCount();
 		assertExpectedEvents(true);
@@ -1421,11 +1364,7 @@ public class EdgeFunctionalTests {
 		HttpConnecting responseConnection = createNetworkResponse(null, edgeResponse, 503, null, null);
 		setNetworkResponseFor(EXEDGE_INTERACT_URL_STRING, POST, responseConnection);
 		setExpectationNetworkRequest(EXEDGE_INTERACT_URL_STRING, POST, 1);
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT,
-			2
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.REQUEST_CONTENT, 2);
 
 		ExperienceEvent event = new ExperienceEvent.Builder()
 			.setXdmSchema(
@@ -1467,11 +1406,7 @@ public class EdgeFunctionalTests {
 		responseConnection = createNetworkResponse(edgeResponse, 200);
 		setExpectationNetworkRequest(EXEDGE_INTERACT_URL_STRING, POST, 2);
 		setNetworkResponseFor(EXEDGE_INTERACT_URL_STRING, POST, responseConnection);
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			2
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 2);
 
 		assertNetworkRequestCount();
 		assertExpectedEvents(false);
@@ -1487,26 +1422,15 @@ public class EdgeFunctionalTests {
 		setNetworkResponseFor(EXEDGE_INTERACT_URL_STRING, POST, responseConnection);
 		setExpectationNetworkRequest(EXEDGE_INTERACT_URL_STRING, POST, 1);
 
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT,
-			1
-		);
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			2
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.REQUEST_CONTENT, 1);
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 2);
 
 		Edge.sendEvent(XDM_EXPERIENCE_EVENT, null);
 
 		assertNetworkRequestCount();
 		assertExpectedEvents(false);
 
-		List<Event> resultEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT
-		);
+		List<Event> resultEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(2, resultEvents.size());
 
 		Map<String, String> eventData1 = FunctionalTestUtils.flattenMap(resultEvents.get(0).getEventData());
@@ -1556,26 +1480,15 @@ public class EdgeFunctionalTests {
 		setNetworkResponseFor(EXEDGE_INTERACT_URL_STRING, POST, responseConnection);
 		setExpectationNetworkRequest(EXEDGE_INTERACT_URL_STRING, POST, 1);
 
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT,
-			1
-		);
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.REQUEST_CONTENT, 1);
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
 
 		Edge.sendEvent(XDM_EXPERIENCE_EVENT, null);
 
 		assertNetworkRequestCount();
 		assertExpectedEvents(false);
 
-		List<Event> resultEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT
-		);
+		List<Event> resultEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(1, resultEvents.size());
 
 		Map<String, String> eventData = FunctionalTestUtils.flattenMap(resultEvents.get(0).getEventData());

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/IdentityStateFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/IdentityStateFunctionalTests.java
@@ -48,10 +48,10 @@ public class IdentityStateFunctionalTests {
 
 	@Before
 	public void setup() throws Exception {
-		setExpectationEvent(EventType.HUB.getName(), EventSource.BOOTED.getName(), 1);
-		setExpectationEvent(EventType.CONFIGURATION.getName(), EventSource.REQUEST_CONTENT.getName(), 1);
-		setExpectationEvent(EventType.CONFIGURATION.getName(), EventSource.RESPONSE_CONTENT.getName(), 1);
-		setExpectationEvent(EventType.HUB.getName(), EventSource.SHARED_STATE.getName(), 3);
+		setExpectationEvent(EventType.HUB, EventSource.BOOTED, 1);
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.REQUEST_CONTENT, 1);
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT, 1);
+		setExpectationEvent(EventType.HUB, EventSource.SHARED_STATE, 3);
 
 		HashMap<String, Object> config = new HashMap<String, Object>() {
 			{

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
@@ -77,10 +77,10 @@ public class NetworkResponseHandlerFunctionalTests {
 
 	@Before
 	public void setup() throws Exception {
-		setExpectationEvent(EventType.HUB.getName(), EventSource.BOOTED.getName(), 1);
-		setExpectationEvent(EventType.CONFIGURATION.getName(), EventSource.REQUEST_CONTENT.getName(), 1);
-		setExpectationEvent(EventType.CONFIGURATION.getName(), EventSource.RESPONSE_CONTENT.getName(), 1);
-		setExpectationEvent(EventType.HUB.getName(), EventSource.SHARED_STATE.getName(), 4);
+		setExpectationEvent(EventType.HUB, EventSource.BOOTED, 1);
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.REQUEST_CONTENT, 1);
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT, 1);
+		setExpectationEvent(EventType.HUB, EventSource.SHARED_STATE, 4);
 
 		HashMap<String, Object> config = new HashMap<String, Object>() {
 			{

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
@@ -119,10 +119,7 @@ public class NetworkResponseHandlerFunctionalTests {
 	public void testProcessResponseOnError_WhenEmptyJsonError_doesNotHandleError() throws InterruptedException {
 		final String jsonError = "";
 		networkResponseHandler.processResponseOnError(jsonError, "123");
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(0, dispatchEvents.size());
 	}
 
@@ -130,31 +127,20 @@ public class NetworkResponseHandlerFunctionalTests {
 	public void testProcessResponseOnError_WhenInvalidJsonError_doesNotHandleError() throws InterruptedException {
 		final String jsonError = "{ invalid json }";
 		networkResponseHandler.processResponseOnError(jsonError, "123");
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(0, dispatchEvents.size());
 	}
 
 	@Test
 	public void testProcessResponseOnError_WhenGenericJsonError_dispatchesEvent() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
 		final String jsonError =
 			"{\n" +
 			"\"type\": \"https://ns.adobe.com/aep/errors/EXEG-0201-503\",\n" +
 			"\"title\": \"Request to Data platform failed with an unknown exception\"" +
 			"\n}";
 		networkResponseHandler.processResponseOnError(jsonError, "123");
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			5000
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 5000);
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -166,11 +152,7 @@ public class NetworkResponseHandlerFunctionalTests {
 
 	@Test
 	public void testProcessResponseOnError_WhenOneEventJsonError_dispatchesEvent() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
 		final String jsonError =
 			"{\n" +
 			"      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
@@ -184,10 +166,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			"      ]\n" +
 			"    }";
 		networkResponseHandler.processResponseOnError(jsonError, "123");
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -203,11 +182,7 @@ public class NetworkResponseHandlerFunctionalTests {
 
 	@Test
 	public void testProcessResponseOnError_WhenValidEventIndex_dispatchesPairedEvent() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
 		final String requestId = "123";
 		final String jsonError =
 			"{\n" +
@@ -232,10 +207,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			}
 		);
 		networkResponseHandler.processResponseOnError(jsonError, requestId);
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -250,11 +222,7 @@ public class NetworkResponseHandlerFunctionalTests {
 
 	@Test
 	public void testProcessResponseOnError_WhenUnknownEventIndex_doesNotCrash() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
 		final String requestId = "123";
 		final String jsonError =
 			"{\n" +
@@ -279,10 +247,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			}
 		);
 		networkResponseHandler.processResponseOnError(jsonError, requestId);
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -296,11 +261,7 @@ public class NetworkResponseHandlerFunctionalTests {
 
 	@Test
 	public void testProcessResponseOnError_WhenUnknownRequestId_doesNotCrash() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
 		final String requestId = "123";
 		final String jsonError =
 			"{\n" +
@@ -325,10 +286,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			}
 		);
 		networkResponseHandler.processResponseOnError(jsonError, "567");
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -342,11 +300,7 @@ public class NetworkResponseHandlerFunctionalTests {
 
 	@Test
 	public void testProcessResponseOnError_WhenTwoEventJsonError_dispatchesTwoEvents() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			2
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 2);
 		final String requestId = "123";
 		final String jsonError =
 			"{\n" +
@@ -366,10 +320,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			"      ]\n" +
 			"    }";
 		networkResponseHandler.processResponseOnError(jsonError, requestId);
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(2, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData1 = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -398,10 +349,7 @@ public class NetworkResponseHandlerFunctionalTests {
 	public void testProcessResponseOnSuccess_WhenEmptyJsonResponse_doesNotDispatchEvent() throws InterruptedException {
 		final String jsonResponse = "";
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, "123");
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.RESPONSE_CONTENT
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.RESPONSE_CONTENT);
 		assertEquals(0, dispatchEvents.size());
 	}
 
@@ -410,20 +358,13 @@ public class NetworkResponseHandlerFunctionalTests {
 		throws InterruptedException {
 		final String jsonResponse = "{ invalid json }";
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, "123");
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.RESPONSE_CONTENT
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.RESPONSE_CONTENT);
 		assertEquals(0, dispatchEvents.size());
 	}
 
 	@Test
 	public void testProcessResponseOnSuccess_WhenOneEventHandle_dispatchesEvent() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.RESPONSE_CONTENT, 1);
 		final String jsonResponse =
 			"{\n" +
 			"      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
@@ -442,7 +383,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			"    }";
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, "123");
 
-		List<Event> dispatchEvents = getDispatchedEventsWith(FunctionalTestConstants.EventType.EDGE, "state:store");
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, "state:store");
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -457,11 +398,7 @@ public class NetworkResponseHandlerFunctionalTests {
 	@Test
 	public void testProcessResponseOnSuccess_WhenOneEventHandle_emptyEventHandleType_dispatchesEvent()
 		throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.RESPONSE_CONTENT, 1);
 		final String jsonResponse =
 			"{\n" +
 			"      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
@@ -480,10 +417,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			"    }";
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, "123");
 
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.RESPONSE_CONTENT
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.RESPONSE_CONTENT);
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -497,11 +431,7 @@ public class NetworkResponseHandlerFunctionalTests {
 	@Test
 	public void testProcessResponseOnSuccess_WhenOneEventHandle_nullEventHandleType_dispatchesEvent()
 		throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.RESPONSE_CONTENT, 1);
 		final String jsonResponse =
 			"{\n" +
 			"      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
@@ -519,10 +449,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			"    }";
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, "123");
 
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.RESPONSE_CONTENT
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.RESPONSE_CONTENT);
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -535,11 +462,7 @@ public class NetworkResponseHandlerFunctionalTests {
 
 	@Test
 	public void testProcessResponseOnSuccess_WhenTwoEventHandles_dispatchesTwoEvents() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.RESPONSE_CONTENT,
-			2
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.RESPONSE_CONTENT, 2);
 		final String jsonResponse =
 			"{\n" +
 			"      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
@@ -568,8 +491,8 @@ public class NetworkResponseHandlerFunctionalTests {
 			"    }";
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, "123");
 
-		List<Event> dispatchEvents = getDispatchedEventsWith(FunctionalTestConstants.EventType.EDGE, "state:store");
-		dispatchEvents.addAll(getDispatchedEventsWith(FunctionalTestConstants.EventType.EDGE, "identity:persist"));
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, "state:store");
+		dispatchEvents.addAll(getDispatchedEventsWith(EventType.EDGE, "identity:persist"));
 		assertEquals(2, dispatchEvents.size());
 
 		// verify event 1
@@ -593,11 +516,7 @@ public class NetworkResponseHandlerFunctionalTests {
 	@Test
 	public void testProcessResponseOnSuccess_WhenEventHandleWithEventIndex_dispatchesEventWithRequestEventId()
 		throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.RESPONSE_CONTENT,
-			2
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.RESPONSE_CONTENT, 2);
 		final String requestId = "123";
 		final String jsonResponse =
 			"{\n" +
@@ -635,8 +554,8 @@ public class NetworkResponseHandlerFunctionalTests {
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, requestId);
 
 		// verify event 1
-		List<Event> dispatchEvents = getDispatchedEventsWith(FunctionalTestConstants.EventType.EDGE, "state:store");
-		dispatchEvents.addAll(getDispatchedEventsWith(FunctionalTestConstants.EventType.EDGE, "pairedeventexample"));
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, "state:store");
+		dispatchEvents.addAll(getDispatchedEventsWith(EventType.EDGE, "pairedeventexample"));
 		assertEquals(2, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData1 = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -660,11 +579,7 @@ public class NetworkResponseHandlerFunctionalTests {
 	@Test
 	public void testProcessResponseOnSuccess_WhenEventHandleWithUnknownEventIndex_dispatchesUnpairedEvent()
 		throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.RESPONSE_CONTENT, 1);
 		final String requestId = "123";
 		final String jsonResponse =
 			"{\n" +
@@ -693,10 +608,7 @@ public class NetworkResponseHandlerFunctionalTests {
 		);
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, requestId);
 
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			"pairedeventexample"
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, "pairedeventexample");
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -708,11 +620,7 @@ public class NetworkResponseHandlerFunctionalTests {
 
 	@Test
 	public void testProcessResponseOnSuccess_WhenUnknownRequestId_doesNotCrash() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.RESPONSE_CONTENT, 1);
 		final String requestId = "123";
 		final String jsonResponse =
 			"{\n" +
@@ -741,10 +649,7 @@ public class NetworkResponseHandlerFunctionalTests {
 		);
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, requestId);
 
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			"pairedeventexample"
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, "pairedeventexample");
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -760,16 +665,8 @@ public class NetworkResponseHandlerFunctionalTests {
 
 	@Test
 	public void testProcessResponseOnSuccess_WhenEventHandleAndError_dispatchesTwoEvents() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.RESPONSE_CONTENT,
-			1
-		);
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.RESPONSE_CONTENT, 1);
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
 		final String requestId = "123";
 		final String jsonResponse =
 			"{\n" +
@@ -795,7 +692,7 @@ public class NetworkResponseHandlerFunctionalTests {
 
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, requestId);
 
-		List<Event> dispatchEvents = getDispatchedEventsWith(FunctionalTestConstants.EventType.EDGE, "state:store");
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, "state:store");
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData1 = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -806,10 +703,7 @@ public class NetworkResponseHandlerFunctionalTests {
 		assertEquals("MCMID|29068398647607325310376254630528178721", flattenReceivedData1.get("payload[0].value"));
 		assertEquals("15552000", flattenReceivedData1.get("payload[0].maxAge"));
 
-		List<Event> dispatchErrorEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT
-		);
+		List<Event> dispatchErrorEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(1, dispatchErrorEvents.size());
 
 		Map<String, String> flattenReceivedData2 = FunctionalTestUtils.flattenMap(
@@ -824,11 +718,7 @@ public class NetworkResponseHandlerFunctionalTests {
 
 	@Test
 	public void testProcessResponseOnSuccess_WhenErrorAndWarning_dispatchesTwoEvents() throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT,
-			2
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 2);
 		final String requestId = "123";
 		final String jsonResponse =
 			"{\n" +
@@ -859,10 +749,7 @@ public class NetworkResponseHandlerFunctionalTests {
 
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, requestId);
 
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.ERROR_RESPONSE_CONTENT
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(2, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData1 = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
@@ -890,11 +777,7 @@ public class NetworkResponseHandlerFunctionalTests {
 	@Test
 	public void testProcessResponseOnSuccess_WhenLocationHintResultEventHandle_dispatchesEvent()
 		throws InterruptedException {
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.RESPONSE_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.RESPONSE_CONTENT, 1);
 		final String jsonResponse =
 			"{\n" +
 			"      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
@@ -917,10 +800,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			"    }";
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, "123");
 
-		List<Event> dispatchEvents = getDispatchedEventsWith(
-			FunctionalTestConstants.EventType.EDGE,
-			"locationHint:result"
-		);
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, "locationHint:result");
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NoConfigFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NoConfigFunctionalTests.java
@@ -101,11 +101,7 @@ public class NoConfigFunctionalTests {
 		final Map<String, Object> identityMap = Utils.toMap(jsonObject);
 
 		resetTestExpectations(); // reset received events
-		setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT,
-			1
-		);
+		setExpectationEvent(EventType.EDGE, EventSource.REQUEST_CONTENT, 1);
 
 		ExperienceEvent experienceEvent = new ExperienceEvent.Builder()
 			.setXdmSchema(

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NoConfigFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NoConfigFunctionalTests.java
@@ -50,8 +50,8 @@ public class NoConfigFunctionalTests {
 
 	@Before
 	public void setup() throws Exception {
-		setExpectationEvent(EventType.HUB.getName(), EventSource.BOOTED.getName(), 1);
-		setExpectationEvent(EventType.HUB.getName(), EventSource.SHARED_STATE.getName(), 2);
+		setExpectationEvent(EventType.HUB, EventSource.BOOTED, 1);
+		setExpectationEvent(EventType.HUB, EventSource.SHARED_STATE, 2);
 
 		Edge.registerExtension();
 		FakeIdentity.registerExtension();

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/RestartFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/RestartFunctionalTests.java
@@ -172,20 +172,20 @@ public class RestartFunctionalTests {
 	 * @throws Exception
 	 */
 	public void setupCore(final boolean restart) throws Exception {
-		setExpectationEvent(EventType.HUB.getName(), EventSource.BOOTED.getName(), 1);
+		setExpectationEvent(EventType.HUB, EventSource.BOOTED, 1);
 
 		if (restart) {
 			// On restart, expect Consent to load preferences from persistence and dispatch them to Hub
-			setExpectationEvent("com.adobe.eventtype.edgeconsent", EventSource.RESPONSE_CONTENT.getName(), 1);
+			setExpectationEvent(EventType.CONSENT, EventSource.RESPONSE_CONTENT, 1);
 		} else {
-			setExpectationEvent(EventType.CONFIGURATION.getName(), EventSource.REQUEST_CONTENT.getName(), 1);
+			setExpectationEvent(EventType.CONFIGURATION, EventSource.REQUEST_CONTENT, 1);
 		}
 
-		setExpectationEvent(EventType.CONFIGURATION.getName(), EventSource.RESPONSE_CONTENT.getName(), 1);
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT, 1);
 
 		// hub shared state update for extensions Edge, Config, Consent, Identity, Hub)
 		// Expect 4 shared state events on clean start. On restart, Consent also sets a shared state
-		setExpectationEvent(EventType.HUB.getName(), EventSource.SHARED_STATE.getName(), restart ? 5 : 4);
+		setExpectationEvent(EventType.HUB, EventSource.SHARED_STATE, restart ? 5 : 4);
 
 		MonitorExtension.registerExtension();
 		Edge.registerExtension();

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/SampleFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/SampleFunctionalTests.java
@@ -64,20 +64,12 @@ public class SampleFunctionalTests {
 
 	@Before
 	public void setup() throws Exception {
-		FunctionalTestHelper.setExpectationEvent(EventType.HUB.getName(), EventSource.BOOTED.getName(), 1);
+		FunctionalTestHelper.setExpectationEvent(EventType.HUB, EventSource.BOOTED, 1);
 		// expectations for update config request&response events
-		FunctionalTestHelper.setExpectationEvent(
-			EventType.CONFIGURATION.getName(),
-			EventSource.REQUEST_CONTENT.getName(),
-			1
-		);
-		FunctionalTestHelper.setExpectationEvent(
-			EventType.CONFIGURATION.getName(),
-			EventSource.RESPONSE_CONTENT.getName(),
-			1
-		);
+		FunctionalTestHelper.setExpectationEvent(EventType.CONFIGURATION, EventSource.REQUEST_CONTENT, 1);
+		FunctionalTestHelper.setExpectationEvent(EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT, 1);
 		// hub shared state update Edge, EventHub, Configuration, and Identity
-		FunctionalTestHelper.setExpectationEvent(EventType.HUB.getName(), EventSource.SHARED_STATE.getName(), 4);
+		FunctionalTestHelper.setExpectationEvent(EventType.HUB, EventSource.SHARED_STATE, 4);
 
 		HashMap<String, Object> config = new HashMap<String, Object>() {
 			{

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/SampleFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/SampleFunctionalTests.java
@@ -188,12 +188,8 @@ public class SampleFunctionalTests {
 
 	@Test
 	public void testSample_AssertNetworkRequestAndResponseEvent() throws InterruptedException {
-		FunctionalTestHelper.setExpectationEvent(
-			FunctionalTestConstants.EventType.EDGE,
-			FunctionalTestConstants.EventSource.REQUEST_CONTENT,
-			1
-		);
-		FunctionalTestHelper.setExpectationEvent(FunctionalTestConstants.EventType.EDGE, "identity:exchange", 1);
+		FunctionalTestHelper.setExpectationEvent(EventType.EDGE, EventSource.REQUEST_CONTENT, 1);
+		FunctionalTestHelper.setExpectationEvent(EventType.EDGE, "identity:exchange", 1);
 
 		final String responseBody =
 			"\u0000{\"requestId\":\"ded17427-c993-4182-8d94-2a169c1a23e2\",\"handle\":[{\"type\":\"identity:exchange\",\"payload\":[{\"type\":\"url\",\"id\":411,\"spec\":{\"url\":\"//cm.everesttech.net/cm/dd?d_uuid=42985602780892980519057012517360930936\",\"hideReferrer\":false,\"ttlMinutes\":10080}}]}]}\n";

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/util/FunctionalTestConstants.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/util/FunctionalTestConstants.java
@@ -16,14 +16,12 @@ public class FunctionalTestConstants {
 	public static final String EVENT_NAME_REQUEST_CONTENT = "AEP Request Event";
 	public static final String EVENT_NAME_RESPONSE_CONTENT = "AEP Response Event Handle";
 	public static final String EVENT_NAME_ERROR_RESPONSE_CONTENT = "AEP Error Response";
-	public static final String EVENT_TYPE_ADOBE_HUB = "com.adobe.eventType.hub";
-	public static final String EVENT_SOURCE_ADOBE_SHARED_STATE = "com.adobe.eventSource.sharedState";
 	public static final int NETWORK_REQUEST_MAX_RETRIES = 5;
 	public static final String EDGE_DATA_STORAGE = "EdgeDataStorage";
 
+	// Event type and sources used by Monitor Extension
 	public class EventType {
 
-		public static final String EDGE = "com.adobe.eventType.edge";
 		public static final String MONITOR = "com.adobe.functional.eventType.monitor";
 
 		private EventType() {}
@@ -31,11 +29,6 @@ public class FunctionalTestConstants {
 
 	public class EventSource {
 
-		public static final String REQUEST_CONTENT = "com.adobe.eventSource.requestContent";
-		public static final String RESPONSE_CONTENT = "com.adobe.eventSource.responseContent";
-		public static final String ERROR_RESPONSE_CONTENT = "com.adobe.eventSource.errorResponseContent";
-
-		// Used by Monitor Extension
 		public static final String SHARED_STATE_REQUEST = "com.adobe.eventSource.sharedStateRequest";
 		public static final String SHARED_STATE_RESPONSE = "com.adobe.eventSource.sharedStateResponse";
 		public static final String UNREGISTER = "com.adobe.eventSource.unregister";

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
@@ -19,31 +19,6 @@ final class EdgeConstants {
 	static final String FRIENDLY_NAME = "Edge";
 	static final String LOG_TAG = FRIENDLY_NAME;
 
-	static final class EventSource {
-
-		static final String REQUEST_CONTENT = "com.adobe.eventSource.requestContent";
-		static final String RESPONSE_CONTENT = "com.adobe.eventSource.responseContent";
-		static final String ERROR_RESPONSE_CONTENT = "com.adobe.eventSource.errorResponseContent";
-		static final String ADOBE_SHARED_STATE = "com.adobe.eventSource.sharedState";
-		static final String UPDATE_CONSENT = "com.adobe.eventSource.updateConsent";
-		static final String RESET_COMPLETE = "com.adobe.eventSource.resetComplete";
-		static final String REQUEST_IDENTITY = "com.adobe.eventSource.requestIdentity";
-		static final String RESPONSE_IDENTITY = "com.adobe.eventSource.responseIdentity";
-		static final String UPDATE_IDENTITY = "com.adobe.eventSource.updateIdentity";
-
-		private EventSource() {}
-	}
-
-	static final class EventType {
-
-		static final String EDGE = "com.adobe.eventType.edge";
-		static final String CONSENT = "com.adobe.eventType.edgeConsent";
-		static final String ADOBE_HUB = "com.adobe.eventType.hub";
-		static final String EDGE_IDENTITY = "com.adobe.eventType.edgeIdentity";
-
-		private EventType() {}
-	}
-
 	static final class EventName {
 
 		static final String REQUEST_CONTENT = "AEP Request Event";

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeExtension.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeExtension.java
@@ -126,64 +126,39 @@ class EdgeExtension extends Extension {
 	 * <p>
 	 * The following listeners are registered during this extension's registration:
 	 * <ul>
-	 *     <li> EventType {@link EdgeConstants.EventType#EDGE} and EventSource {@link EdgeConstants.EventSource#REQUEST_CONTENT}</li>
-	 *     <li> EventType {@link EdgeConstants.EventType#CONSENT} and EventSource {@link EdgeConstants.EventSource#RESPONSE_CONTENT}</li>
-	 *     <li> EventType {@link EdgeConstants.EventType#EDGE} and EventSource {@link EdgeConstants.EventSource#UPDATE_CONSENT}</li>
-	 *     <li> EventType {@link EdgeConstants.EventType#EDGE_IDENTITY} and EventSource {@link EdgeConstants.EventSource#RESET_COMPLETE}</li>
-	 *     <li> EventType {@link EdgeConstants.EventType#EDGE} and EventSource {@link EdgeConstants.EventSource#REQUEST_IDENTITY}</li>
-	 *     <li> EventType {@link EdgeConstants.EventType#EDGE} and EventSource {@link EdgeConstants.EventSource#UPDATE_IDENTITY}</li>
+	 *     <li> EventType {@link EventType#EDGE} and EventSource {@link EventSource#REQUEST_CONTENT}</li>
+	 *     <li> EventType {@link EventType#CONSENT} and EventSource {@link EventSource#RESPONSE_CONTENT}</li>
+	 *     <li> EventType {@link EventType#EDGE} and EventSource {@link EventSource#UPDATE_CONSENT}</li>
+	 *     <li> EventType {@link EventType#EDGE_IDENTITY} and EventSource {@link EventSource#RESET_COMPLETE}</li>
+	 *     <li> EventType {@link EventType#EDGE} and EventSource {@link EventSource#REQUEST_IDENTITY}</li>
+	 *     <li> EventType {@link EventType#EDGE} and EventSource {@link EventSource#UPDATE_IDENTITY}</li>
 	 * </ul>
 	 * </p>
 	 */
 	@Override
 	protected void onRegistered() {
 		// register a listener for Edge request events
-		getApi()
-			.registerEventListener(
-				EdgeConstants.EventType.EDGE,
-				EdgeConstants.EventSource.REQUEST_CONTENT,
-				this::handleExperienceEventRequest
-			);
+		getApi().registerEventListener(EventType.EDGE, EventSource.REQUEST_CONTENT, this::handleExperienceEventRequest);
 
 		// register listener for consent preferences updates to update the queue state
 		getApi()
 			.registerEventListener(
-				EdgeConstants.EventType.CONSENT,
-				EdgeConstants.EventSource.RESPONSE_CONTENT,
+				EventType.CONSENT,
+				EventSource.RESPONSE_CONTENT,
 				this::handleConsentPreferencesUpdate
 			);
 
 		// register listener for consent update request events
-		getApi()
-			.registerEventListener(
-				EdgeConstants.EventType.EDGE,
-				EdgeConstants.EventSource.UPDATE_CONSENT,
-				this::handleConsentUpdate
-			);
+		getApi().registerEventListener(EventType.EDGE, EventSource.UPDATE_CONSENT, this::handleConsentUpdate);
 
 		// register listener for identity reset complete
-		getApi()
-			.registerEventListener(
-				EdgeConstants.EventType.EDGE_IDENTITY,
-				EdgeConstants.EventSource.RESET_COMPLETE,
-				this::handleResetComplete
-			);
+		getApi().registerEventListener(EventType.EDGE_IDENTITY, EventSource.RESET_COMPLETE, this::handleResetComplete);
 
 		// register listener for edge get location hint
-		getApi()
-			.registerEventListener(
-				EdgeConstants.EventType.EDGE,
-				EdgeConstants.EventSource.REQUEST_IDENTITY,
-				this::handleGetLocationHint
-			);
+		getApi().registerEventListener(EventType.EDGE, EventSource.REQUEST_IDENTITY, this::handleGetLocationHint);
 
 		// register listener for edge update location hint
-		getApi()
-			.registerEventListener(
-				EdgeConstants.EventType.EDGE,
-				EdgeConstants.EventSource.UPDATE_IDENTITY,
-				this::handleSetLocationHint
-			);
+		getApi().registerEventListener(EventType.EDGE, EventSource.UPDATE_IDENTITY, this::handleSetLocationHint);
 	}
 
 	@Override
@@ -226,7 +201,7 @@ class EdgeExtension extends Extension {
 	}
 
 	/**
-	 * Handles the {@link EdgeConstants.EventType#CONSENT} - {@link EdgeConstants.EventSource#RESPONSE_CONTENT} event for the collect consent change
+	 * Handles the {@link EventType#CONSENT} - {@link EventSource#RESPONSE_CONTENT} event for the collect consent change
 	 *
 	 * @param event current event to process; the event and the event data should not be null, checking in listener
 	 */
@@ -235,7 +210,7 @@ class EdgeExtension extends Extension {
 	}
 
 	/**
-	 * Handles the {@link EdgeConstants.EventType#EDGE_IDENTITY} - {@link EdgeConstants.EventSource#RESET_COMPLETE} event for the identities reset completion
+	 * Handles the {@link EventType#EDGE_IDENTITY} - {@link EventSource#RESET_COMPLETE} event for the identities reset completion
 	 *
 	 * @param event current event to process
 	 */
@@ -263,15 +238,15 @@ class EdgeExtension extends Extension {
 	}
 
 	/**
-	 * Handles the {@link EdgeConstants.EventType#EDGE} - {@link EdgeConstants.EventSource#REQUEST_IDENTITY} event for getting the location hint.
+	 * Handles the {@link EventType#EDGE} - {@link EventSource#REQUEST_IDENTITY} event for getting the location hint.
 	 *
 	 * @param event current event to process
 	 */
 	void handleGetLocationHint(@NonNull final Event event) {
 		Event responseEvent = new Event.Builder(
 			EdgeConstants.EventName.RESPONSE_LOCATION_HINT,
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.RESPONSE_IDENTITY
+			EventType.EDGE,
+			EventSource.RESPONSE_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -287,7 +262,7 @@ class EdgeExtension extends Extension {
 	}
 
 	/**
-	 * Handles the {@link EdgeConstants.EventType#EDGE} - {@link EdgeConstants.EventSource#UPDATE_IDENTITY} event for setting the location hint.
+	 * Handles the {@link EventType#EDGE} - {@link EventSource#UPDATE_IDENTITY} event for setting the location hint.
 	 *
 	 * @param event current event to process
 	 */

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
@@ -307,8 +307,8 @@ class NetworkResponseHandler {
 				eventDataResponse.put(EdgeConstants.EventDataKey.EDGE_REQUEST_ID, requestId);
 				Event responseEvent = new Event.Builder(
 					EdgeConstants.EventName.ERROR_RESPONSE_CONTENT,
-					EdgeConstants.EventType.EDGE,
-					EdgeConstants.EventSource.ERROR_RESPONSE_CONTENT
+					EventType.EDGE,
+					EventSource.ERROR_RESPONSE_CONTENT
 				)
 					.setEventData(eventDataResponse)
 					.build();
@@ -409,8 +409,8 @@ class NetworkResponseHandler {
 	 * @param requestId The request identifier associated with this response event, used for logging
 	 * @param isError indicates if this should be dispatched as an error or regular response content event
 	 * @param eventSource an optional {@link String} to be used as the event source.
-	 *        If {@code eventSource} is nil, either {@link EdgeConstants.EventSource#ERROR_RESPONSE_CONTENT} or
-	 *        {@link EdgeConstants.EventSource#RESPONSE_CONTENT} is used for the event source depending on {@code isError}.
+	 *        If {@code eventSource} is nil, either {@link EventSource#ERROR_RESPONSE_CONTENT} or
+	 *        {@link EventSource#RESPONSE_CONTENT} is used for the event source depending on {@code isError}.
 	 */
 	private void dispatchResponse(
 		final Map<String, Object> eventData,
@@ -422,9 +422,7 @@ class NetworkResponseHandler {
 			return;
 		}
 
-		String source = isError
-			? EdgeConstants.EventSource.ERROR_RESPONSE_CONTENT
-			: EdgeConstants.EventSource.RESPONSE_CONTENT;
+		String source = isError ? EventSource.ERROR_RESPONSE_CONTENT : EventSource.RESPONSE_CONTENT;
 
 		if (!Utils.isNullOrEmpty(eventSource)) {
 			source = eventSource;
@@ -443,7 +441,7 @@ class NetworkResponseHandler {
 		};
 		Event responseEvent = new Event.Builder(
 			isError ? EdgeConstants.EventName.ERROR_RESPONSE_CONTENT : EdgeConstants.EventName.RESPONSE_CONTENT,
-			EdgeConstants.EventType.EDGE,
+			EventType.EDGE,
 			source
 		)
 			.setEventData(eventData)

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeExtensionListenerTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeExtensionListenerTests.java
@@ -36,8 +36,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Request Content",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_CONTENT
+			EventType.EDGE,
+			EventSource.REQUEST_CONTENT
 		)
 			.build();
 		doReturn(null).when(listener).getParentExtension();
@@ -71,8 +71,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Request Content",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_CONTENT
+			EventType.EDGE,
+			EventSource.REQUEST_CONTENT
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -98,8 +98,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Request Content",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_CONTENT
+			EventType.EDGE,
+			EventSource.REQUEST_CONTENT
 		)
 			.setEventData(new HashMap<String, Object>())
 			.build();
@@ -119,8 +119,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Update Consent",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.UPDATE_CONSENT
+			EventType.EDGE,
+			EventSource.UPDATE_CONSENT
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -146,8 +146,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Update Consent",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.UPDATE_CONSENT
+			EventType.EDGE,
+			EventSource.UPDATE_CONSENT
 		)
 			.setEventData(new HashMap<String, Object>())
 			.build();
@@ -167,8 +167,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Consent preferences",
-			EdgeConstants.EventType.CONSENT,
-			EdgeConstants.EventSource.RESPONSE_CONTENT
+			EventType.CONSENT,
+			EventSource.RESPONSE_CONTENT
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -194,8 +194,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Consent preferences",
-			EdgeConstants.EventType.CONSENT,
-			EdgeConstants.EventSource.RESPONSE_CONTENT
+			EventType.CONSENT,
+			EventSource.RESPONSE_CONTENT
 		)
 			.build();
 		doReturn(testExecutor).when(mockEdgeExtension).getExecutor();
@@ -214,8 +214,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Shared State Update",
-			EdgeConstants.EventType.ADOBE_HUB,
-			EdgeConstants.EventSource.ADOBE_SHARED_STATE
+			EventType.HUB,
+			EventSource.SHARED_STATE
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -241,8 +241,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Identity Reset Complete",
-			EdgeConstants.EventType.EDGE_IDENTITY,
-			EdgeConstants.EventSource.RESET_COMPLETE
+			EventType.EDGE_IDENTITY,
+			EventSource.RESET_COMPLETE
 		)
 			.build();
 		doReturn(testExecutor).when(mockEdgeExtension).getExecutor();
@@ -261,8 +261,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Shared State Update",
-			EdgeConstants.EventType.ADOBE_HUB,
-			EdgeConstants.EventSource.ADOBE_SHARED_STATE
+			EventType.HUB,
+			EventSource.SHARED_STATE
 		)
 			.setEventData(new HashMap<String, Object>())
 			.build();
@@ -282,8 +282,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Get Location Hint",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_IDENTITY
+			EventType.EDGE,
+			EventSource.REQUEST_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -309,8 +309,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Get Location Hint",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_IDENTITY
+			EventType.EDGE,
+			EventSource.REQUEST_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -336,8 +336,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Get Location Hint",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_IDENTITY
+			EventType.EDGE,
+			EventSource.REQUEST_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -363,8 +363,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Get Location Hint",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_IDENTITY
+			EventType.EDGE,
+			EventSource.REQUEST_IDENTITY
 		)
 			.setEventData(new HashMap<String, Object>())
 			.build();
@@ -384,8 +384,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Get Location Hint",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_IDENTITY
+			EventType.EDGE,
+			EventSource.REQUEST_IDENTITY
 		)
 			.build();
 		doReturn(testExecutor).when(mockEdgeExtension).getExecutor();
@@ -404,8 +404,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Set Location Hint",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.UPDATE_IDENTITY
+			EventType.EDGE,
+			EventSource.UPDATE_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -431,8 +431,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Set Location Hint",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.UPDATE_IDENTITY
+			EventType.EDGE,
+			EventSource.UPDATE_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -458,8 +458,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Set Location Hint",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.UPDATE_IDENTITY
+			EventType.EDGE,
+			EventSource.UPDATE_IDENTITY
 		)
 			.setEventData(new HashMap<String, Object>())
 			.build();
@@ -479,8 +479,8 @@ public class EdgeExtensionListenerTests {
 		// setup
 		Event event = new Event.Builder(
 			"Edge Set Location Hint",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.UPDATE_IDENTITY
+			EventType.EDGE,
+			EventSource.UPDATE_IDENTITY
 		)
 			.build();
 		doReturn(testExecutor).when(mockEdgeExtension).getExecutor();

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeExtensionTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeExtensionTest.java
@@ -48,11 +48,7 @@ public class EdgeExtensionTest {
 		}
 	};
 
-	private Event event1 = new Event.Builder(
-		"event1",
-		EdgeConstants.EventType.EDGE,
-		EdgeConstants.EventSource.REQUEST_CONTENT
-	)
+	private Event event1 = new Event.Builder("event1", EventType.EDGE, EventSource.REQUEST_CONTENT)
 		.setEventData(
 			new HashMap<String, Object>() {
 				{
@@ -62,11 +58,7 @@ public class EdgeExtensionTest {
 		)
 		.build();
 
-	private Event getHintEvent = new Event.Builder(
-		"Get Location Hint",
-		EdgeConstants.EventType.EDGE,
-		EdgeConstants.EventSource.REQUEST_IDENTITY
-	)
+	private Event getHintEvent = new Event.Builder("Get Location Hint", EventType.EDGE, EventSource.REQUEST_IDENTITY)
 		.setEventData(
 			new HashMap<String, Object>() {
 				{
@@ -198,7 +190,7 @@ public class EdgeExtensionTest {
 	@Test
 	public void testHandleConsentUpdate_queues() {
 		edgeExtension.handleConsentUpdate(
-			new Event.Builder("Consent update", EdgeConstants.EventType.EDGE, EdgeConstants.EventSource.UPDATE_CONSENT)
+			new Event.Builder("Consent update", EventType.EDGE, EventSource.UPDATE_CONSENT)
 				.setEventData(getConsentsData(ConsentStatus.YES))
 				.build()
 		);
@@ -212,11 +204,7 @@ public class EdgeExtensionTest {
 	@Test
 	public void testHandlePreferencesUpdate_validData() {
 		edgeExtension.handleConsentPreferencesUpdate(
-			new Event.Builder(
-				"Consent update",
-				EdgeConstants.EventType.CONSENT,
-				EdgeConstants.EventSource.RESPONSE_CONTENT
-			)
+			new Event.Builder("Consent update", EventType.CONSENT, EventSource.RESPONSE_CONTENT)
 				.setEventData(getConsentsData(ConsentStatus.YES))
 				.build()
 		);
@@ -239,11 +227,7 @@ public class EdgeExtensionTest {
 		)
 			.thenReturn(getHubExtensions(false));
 		edgeExtension.handleSharedStateUpdate(
-			new Event.Builder(
-				"Shared State update",
-				EdgeConstants.EventType.ADOBE_HUB,
-				EdgeConstants.EventSource.ADOBE_SHARED_STATE
-			)
+			new Event.Builder("Shared State update", EventType.HUB, EventSource.SHARED_STATE)
 				.setEventData(
 					new HashMap<String, Object>() {
 						{
@@ -268,11 +252,7 @@ public class EdgeExtensionTest {
 		)
 			.thenReturn(getHubExtensions(true));
 		edgeExtension.handleSharedStateUpdate(
-			new Event.Builder(
-				"Shared State update",
-				EdgeConstants.EventType.ADOBE_HUB,
-				EdgeConstants.EventSource.ADOBE_SHARED_STATE
-			)
+			new Event.Builder("Shared State update", EventType.HUB, EventSource.SHARED_STATE)
 				.setEventData(
 					new HashMap<String, Object>() {
 						{
@@ -297,11 +277,7 @@ public class EdgeExtensionTest {
 		)
 			.thenReturn(getHubExtensions(true));
 		edgeExtension.handleSharedStateUpdate(
-			new Event.Builder(
-				"Shared State update",
-				EdgeConstants.EventType.ADOBE_HUB,
-				EdgeConstants.EventSource.ADOBE_SHARED_STATE
-			)
+			new Event.Builder("Shared State update", EventType.HUB, EventSource.SHARED_STATE)
 				.setEventData(
 					new HashMap<String, Object>() {
 						{
@@ -469,11 +445,7 @@ public class EdgeExtensionTest {
 
 	@Test
 	public void testhandleSetLocationHint_whenValueHint_setsHint() {
-		final Event requestEvent = new Event.Builder(
-			"Set Location Hint",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.UPDATE_IDENTITY
-		)
+		final Event requestEvent = new Event.Builder("Set Location Hint", EventType.EDGE, EventSource.UPDATE_IDENTITY)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{
@@ -491,11 +463,7 @@ public class EdgeExtensionTest {
 	@Test
 	public void testhandleSetLocationHint_whenEmptyHint_clearsHint() {
 		state.setLocationHint("or2", 1800);
-		final Event requestEvent = new Event.Builder(
-			"Set Location Hint",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.UPDATE_IDENTITY
-		)
+		final Event requestEvent = new Event.Builder("Set Location Hint", EventType.EDGE, EventSource.UPDATE_IDENTITY)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{
@@ -513,11 +481,7 @@ public class EdgeExtensionTest {
 	@Test
 	public void testhandleSetLocationHint_whenNullHint_clearsHint() {
 		state.setLocationHint("or2", 1800);
-		final Event requestEvent = new Event.Builder(
-			"Set Location Hint",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.UPDATE_IDENTITY
-		)
+		final Event requestEvent = new Event.Builder("Set Location Hint", EventType.EDGE, EventSource.UPDATE_IDENTITY)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorTests.java
@@ -96,8 +96,8 @@ public class EdgeHitProcessorTests {
 
 	private Event experienceEvent = new Event.Builder(
 		"test-experience-event",
-		EdgeConstants.EventType.EDGE,
-		EdgeConstants.EventSource.REQUEST_CONTENT
+		EventType.EDGE,
+		EventSource.REQUEST_CONTENT
 	)
 		.setEventData(
 			new HashMap<String, Object>() {
@@ -115,11 +115,7 @@ public class EdgeHitProcessorTests {
 		)
 		.build();
 
-	private Event consentEvent = new Event.Builder(
-		"test-consent-event",
-		EdgeConstants.EventType.EDGE,
-		EdgeConstants.EventSource.UPDATE_CONSENT
-	)
+	private Event consentEvent = new Event.Builder("test-consent-event", EventType.EDGE, EventSource.UPDATE_CONSENT)
 		.setEventData(
 			new HashMap<String, Object>() {
 				{
@@ -434,11 +430,7 @@ public class EdgeHitProcessorTests {
 	@Test
 	public void testProcessHit_onResetHit_clearsStatePayloads() throws InterruptedException {
 		// setup
-		final Event resetEvent = new Event.Builder(
-			"Reset Event",
-			EdgeConstants.EventType.EDGE_IDENTITY,
-			EdgeConstants.EventSource.RESET_COMPLETE
-		)
+		final Event resetEvent = new Event.Builder("Reset Event", EventType.EDGE_IDENTITY, EventSource.RESET_COMPLETE)
 			.build();
 		final EdgeDataEntity entity = new EdgeDataEntity(resetEvent);
 
@@ -514,11 +506,7 @@ public class EdgeHitProcessorTests {
 	@Test
 	public void testProcessHit_consentUpdateEvent_emptyData_doesNotSendNetworkRequest_returnsTrue() {
 		// setup
-		Event consentEvent = new Event.Builder(
-			"test-consent-event",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.UPDATE_CONSENT
-		)
+		Event consentEvent = new Event.Builder("test-consent-event", EventType.EDGE, EventSource.UPDATE_CONSENT)
 			.build();
 		EdgeDataEntity entity = new EdgeDataEntity(consentEvent, edgeConfig, identityMap);
 
@@ -529,11 +517,7 @@ public class EdgeHitProcessorTests {
 	@Test
 	public void testProcessHit_consentUpdateEvent_emptyPayloadDueToInvalidData_doesNotSendNetworkRequest_returnsTrue() {
 		// setup
-		Event consentEvent = new Event.Builder(
-			"test-consent-event",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.UPDATE_CONSENT
-		)
+		Event consentEvent = new Event.Builder("test-consent-event", EventType.EDGE, EventSource.UPDATE_CONSENT)
 			.setEventData(
 				new HashMap<String, Object>() {
 					{

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgePublicAPITests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgePublicAPITests.java
@@ -128,8 +128,8 @@ public class EdgePublicAPITests {
 
 		Event responseEvent = new Event.Builder(
 			EdgeConstants.EventName.RESPONSE_LOCATION_HINT,
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.RESPONSE_IDENTITY
+			EventType.EDGE,
+			EventSource.RESPONSE_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -180,8 +180,8 @@ public class EdgePublicAPITests {
 
 		Event responseEvent = new Event.Builder(
 			EdgeConstants.EventName.RESPONSE_LOCATION_HINT,
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.RESPONSE_IDENTITY
+			EventType.EDGE,
+			EventSource.RESPONSE_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -269,8 +269,8 @@ public class EdgePublicAPITests {
 
 		Event responseEvent = new Event.Builder(
 			EdgeConstants.EventName.RESPONSE_LOCATION_HINT,
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.RESPONSE_IDENTITY
+			EventType.EDGE,
+			EventSource.RESPONSE_IDENTITY
 		)
 			.setEventData(null)
 			.build();
@@ -315,8 +315,8 @@ public class EdgePublicAPITests {
 
 		Event responseEvent = new Event.Builder(
 			EdgeConstants.EventName.RESPONSE_LOCATION_HINT,
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.RESPONSE_IDENTITY
+			EventType.EDGE,
+			EventSource.RESPONSE_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {
@@ -367,8 +367,8 @@ public class EdgePublicAPITests {
 
 		Event responseEvent = new Event.Builder(
 			EdgeConstants.EventName.RESPONSE_LOCATION_HINT,
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.RESPONSE_IDENTITY
+			EventType.EDGE,
+			EventSource.RESPONSE_IDENTITY
 		)
 			.setEventData(
 				new HashMap<String, Object>() {

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
@@ -441,12 +441,7 @@ public class NetworkResponseHandlerTest {
 
 	@Test
 	public void testProcessResponseOnSuccess_beforeReset_doesNotSavePayloads() {
-		final Event event = new Event.Builder(
-			"test Event",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_CONTENT
-		)
-			.build();
+		final Event event = new Event.Builder("test Event", EventType.EDGE, EventSource.REQUEST_CONTENT).build();
 		networkResponseHandler.addWaitingEvent("123", event);
 		final long resetTime = event.getTimestamp() + 10; // reset received after event was queued, ignore its state store
 		networkResponseHandler.setLastResetDate(resetTime);
@@ -475,12 +470,7 @@ public class NetworkResponseHandlerTest {
 
 	@Test
 	public void testProcessResponseOnSuccess_afterReset_doesSavePayloads() {
-		final Event event = new Event.Builder(
-			"test Event",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_CONTENT
-		)
-			.build();
+		final Event event = new Event.Builder("test Event", EventType.EDGE, EventSource.REQUEST_CONTENT).build();
 		networkResponseHandler.addWaitingEvent("123", event);
 		final long resetTime = event.getTimestamp() - 10; // reset received before event was queued, save its state store
 		networkResponseHandler.setLastResetDate(resetTime);
@@ -510,12 +500,7 @@ public class NetworkResponseHandlerTest {
 
 	@Test
 	public void testProcessResponseOnSuccess_beforePersistedReset_doesNotSavePayloads() {
-		final Event event = new Event.Builder(
-			"test Event",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_CONTENT
-		)
-			.build();
+		final Event event = new Event.Builder("test Event", EventType.EDGE, EventSource.REQUEST_CONTENT).build();
 		final long resetTime = event.getTimestamp() + 10; // reset received after event was queued, ignore its state store
 
 		when(mockNamedCollection.getLong(EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, 0)).thenReturn(resetTime);
@@ -546,12 +531,7 @@ public class NetworkResponseHandlerTest {
 
 	@Test
 	public void testProcessResponseOnSuccess_afterPersistedReset_doesSavePayloads() {
-		final Event event = new Event.Builder(
-			"test Event",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_CONTENT
-		)
-			.build();
+		final Event event = new Event.Builder("test Event", EventType.EDGE, EventSource.REQUEST_CONTENT).build();
 		final long resetTime = event.getTimestamp() - 10; // reset received before event was queued, save its state store
 		mockNamedCollection.setLong(EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, resetTime);
 
@@ -1417,12 +1397,7 @@ public class NetworkResponseHandlerTest {
 
 	@Test
 	public void testProcessResponseOnSuccess_beforeReset_doesNotSetLocationHint() {
-		final Event event = new Event.Builder(
-			"test Event",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_CONTENT
-		)
-			.build();
+		final Event event = new Event.Builder("test Event", EventType.EDGE, EventSource.REQUEST_CONTENT).build();
 		networkResponseHandler.addWaitingEvent("123", event);
 		final long resetTime = event.getTimestamp() + 10;
 		networkResponseHandler.setLastResetDate(resetTime);
@@ -1451,12 +1426,7 @@ public class NetworkResponseHandlerTest {
 
 	@Test
 	public void testProcessResponseOnSuccess_afterReset_setsLocationHint() {
-		final Event event = new Event.Builder(
-			"test Event",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_CONTENT
-		)
-			.build();
+		final Event event = new Event.Builder("test Event", EventType.EDGE, EventSource.REQUEST_CONTENT).build();
 		networkResponseHandler.addWaitingEvent("123", event);
 		final long resetTime = event.getTimestamp() - 10;
 		networkResponseHandler.setLastResetDate(resetTime);
@@ -1485,12 +1455,7 @@ public class NetworkResponseHandlerTest {
 
 	@Test
 	public void testProcessResponseOnSuccess_beforePersistedReset_doesNotSetLocationHint() {
-		final Event event = new Event.Builder(
-			"test Event",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_CONTENT
-		)
-			.build();
+		final Event event = new Event.Builder("test Event", EventType.EDGE, EventSource.REQUEST_CONTENT).build();
 		final long resetTime = event.getTimestamp() + 10;
 		when(mockNamedCollection.getLong(EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, 0)).thenReturn(resetTime);
 		// reset response handler to load persisted reset time
@@ -1521,12 +1486,7 @@ public class NetworkResponseHandlerTest {
 
 	@Test
 	public void testProcessResponseOnSuccess_afterPersistedReset_setsLocationHint() {
-		final Event event = new Event.Builder(
-			"test Event",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_CONTENT
-		)
-			.build();
+		final Event event = new Event.Builder("test Event", EventType.EDGE, EventSource.REQUEST_CONTENT).build();
 		final long resetTime = event.getTimestamp() - 10;
 
 		mockNamedCollection.setLong(EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, resetTime);

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/RequestBuilderTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/RequestBuilderTest.java
@@ -624,11 +624,7 @@ public class RequestBuilderTest {
 	}
 
 	private List<Event> getSingleEvent(final Map<String, Object> eventData) {
-		final Event event = new Event.Builder(
-			"Request Builder Test Event",
-			EdgeConstants.EventType.EDGE,
-			EdgeConstants.EventSource.REQUEST_CONTENT
-		)
+		final Event event = new Event.Builder("Request Builder Test Event", EventType.EDGE, EventSource.REQUEST_CONTENT)
 			.setEventData(eventData)
 			.build();
 
@@ -643,11 +639,7 @@ public class RequestBuilderTest {
 		List<Event> events = new ArrayList<>(eventData.size());
 
 		for (Map<String, Object> data : eventData) {
-			Event event = new Event.Builder(
-				"Request Builder Test Event",
-				EdgeConstants.EventType.EDGE,
-				EdgeConstants.EventSource.REQUEST_CONTENT
-			)
+			Event event = new Event.Builder("Request Builder Test Event", EventType.EDGE, EventSource.REQUEST_CONTENT)
 				.setEventData(data)
 				.build();
 			events.add(event);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Remove the EventType/Source constants from the extension source, and use these constants from Core.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Core 2.x made EventType and Source public.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
