### PR TITLE
[MOB-17092] Use TimeUtils for xdm timestamp format

### DIFF
--- a/code/app/src/main/java/com/adobe/marketing/mobile/xdm/MobileSDKCommerceSchema.java
+++ b/code/app/src/main/java/com/adobe/marketing/mobile/xdm/MobileSDKCommerceSchema.java
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.xdm;
 
+import com.adobe.marketing.mobile.util.TimeUtils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +85,7 @@ public class MobileSDKCommerceSchema implements com.adobe.marketing.mobile.xdm.S
 		}
 
 		if (this.timestamp != null) {
-			map.put("timestamp", com.adobe.marketing.mobile.xdm.Formatters.dateToISO8601String(this.timestamp));
+			map.put("timestamp", TimeUtils.getISO8601UTCDateWithMilliseconds(this.timestamp));
 		}
 
 		return map;

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/util/TestXDMSchema.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/util/TestXDMSchema.java
@@ -66,7 +66,7 @@ public class TestXDMSchema implements Schema {
 		}
 
 		if (this.timestamp != null) {
-			map.put("timestamp", com.adobe.marketing.mobile.xdm.Formatters.dateToISO8601String(this.timestamp));
+			map.put("timestamp", TimeUtils.getISO8601UTCDateWithMilliseconds(this.timestamp));
 		}
 
 		return map;

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/RequestBuilder.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/RequestBuilder.java
@@ -17,14 +17,12 @@ import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.NamedCollection;
 import com.adobe.marketing.mobile.util.CloneFailedException;
 import com.adobe.marketing.mobile.util.EventDataUtils;
-import java.text.SimpleDateFormat;
+import com.adobe.marketing.mobile.util.TimeUtils;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.TimeZone;
 import org.json.JSONObject;
 
 class RequestBuilder {
@@ -37,14 +35,6 @@ class RequestBuilder {
 
 	// Control character used at the end of each response fragment
 	private String streamingLineFeed;
-
-	private static final SimpleDateFormat iso6801DateFormat;
-
-	static {
-		final Locale posixLocale = new Locale(Locale.US.getLanguage(), Locale.US.getCountry(), "POSIX");
-		iso6801DateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", posixLocale);
-		iso6801DateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-	}
 
 	private static final Map<String, Object> consentQueryOptions;
 
@@ -249,7 +239,7 @@ class RequestBuilder {
 		// if no timestamp is provided in the xdm event payload, set the event timestamp
 		if (timestampFromPayload == null || timestampFromPayload.isEmpty()) {
 			long eventTimestamp = event.getTimestamp();
-			String eventTimestampString = iso6801DateFormat.format(new Date(eventTimestamp));
+			String eventTimestampString = TimeUtils.getISO8601UTCDateWithMilliseconds(new Date(eventTimestamp));
 			xdm.put(EdgeJson.Event.Xdm.TIMESTAMP, eventTimestampString);
 		}
 	}

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/xdm/Formatters.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/xdm/Formatters.java
@@ -56,7 +56,10 @@ public final class Formatters {
 	 * @param timestamp a timestamp
 	 * @return {@code timestamp} formatted to a string in the format of 'yyyy-MM-dd'T'HH:mm:ss'Z'',
 	 * or an empty string if {@code timestamp} is null
+	 *
+	 * @deprecated as of 2.0.0, replaced by {@code TimeUtils.getISO8601UTCDateWithMilliseconds} from Mobile Core
 	 */
+	@Deprecated
 	public static String dateToISO8601String(final Date timestamp) {
 		if (timestamp == null) {
 			return "";
@@ -76,7 +79,10 @@ public final class Formatters {
 	 * @param date a date
 	 * @return {@code date} formatted to a string in the format of 'yyy-MM-dd', or an empty string
 	 * if {@code date} is null
+	 *
+	 * @deprecated as of 2.0.0, replaced by {@code TimeUtils.getISO8601FullDate} from Mobile Core
 	 */
+	@Deprecated
 	public static String dateToShortDateString(final Date date) {
 		if (date == null) {
 			return "";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Use TimeUtils for xdm timestamp format, kept the formatTimestamp util for testing purposes only
- Deprecate XDM Formatters for time/date and updated test app usages for the same

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
