### PR TITLE
Set parent ID to Edge response events

### DIFF
--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
@@ -914,6 +914,7 @@ public class EdgeFunctionalTests {
 		assertEquals("buttonColor", flattenedEventData.get("payload[0].scope"));
 		assertEquals(requestId, flattenedEventData.get("requestId"));
 		assertEquals(requestEventUuid, flattenedEventData.get("requestEventId"));
+		assertEquals(requestEventUuid, responseEvents.get(0).getParentID());
 	}
 
 	@Test
@@ -967,6 +968,7 @@ public class EdgeFunctionalTests {
 		assertEquals("0", flattenedEventData.get("eventIndex"));
 		assertEquals(requestId, flattenedEventData.get("requestId"));
 		assertEquals(requestEventUuid, flattenedEventData.get("requestEventId"));
+		assertEquals(requestEventUuid, errorResponseEvents.get(0).getParentID());
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -1237,6 +1239,25 @@ public class EdgeFunctionalTests {
 		assertEquals(expectedHint, result[0]);
 	}
 
+	@Test
+	public void testGetLocationHint_responseEventChainedToParentId() throws InterruptedException {
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		Edge.setLocationHint("or2");
+		Edge.getLocationHint(s -> {
+			latch.countDown();
+		});
+
+		latch.await(2000, TimeUnit.MILLISECONDS);
+
+		List<Event> dispatchedRequests = getDispatchedEventsWith(EventType.EDGE, EventSource.REQUEST_IDENTITY);
+		assertEquals(1, dispatchedRequests.size());
+		List<Event> dispatchedResponses = getDispatchedEventsWith(EventType.EDGE, EventSource.RESPONSE_IDENTITY);
+		assertEquals(1, dispatchedResponses.size());
+
+		assertEquals(dispatchedRequests.get(0).getUniqueIdentifier(), dispatchedResponses.get(0).getParentID());
+	}
+
 	// --------------------------------------------------------------------------------------------
 	// test persisted hits (recoverable errors)
 	// --------------------------------------------------------------------------------------------
@@ -1389,6 +1410,9 @@ public class EdgeFunctionalTests {
 		assertNetworkRequestCount();
 		assertExpectedEvents(false);
 
+		List<Event> requestEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.REQUEST_CONTENT);
+		assertEquals(1, requestEvents.size());
+
 		List<Event> resultEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(2, resultEvents.size());
 
@@ -1401,6 +1425,8 @@ public class EdgeFunctionalTests {
 			"The 'com.adobe.experience.platform.ode' service is temporarily unable to serve this request. Please try again later.",
 			eventData1.get("title")
 		);
+		assertEquals(requestEvents.get(0).getUniqueIdentifier(), eventData1.get("requestEventId"));
+		assertEquals(requestEvents.get(0).getUniqueIdentifier(), resultEvents.get(0).getParentID());
 
 		Map<String, String> eventData2 = FunctionalTestUtils.flattenMap(resultEvents.get(1).getEventData());
 		assertEquals(8, eventData2.size());
@@ -1413,6 +1439,8 @@ public class EdgeFunctionalTests {
 		);
 		assertEquals("Cannot read related customer for device id: ...", eventData2.get("report.cause.message"));
 		assertEquals("202", eventData2.get("report.cause.code"));
+		assertEquals(requestEvents.get(0).getUniqueIdentifier(), eventData2.get("requestEventId"));
+		assertEquals(requestEvents.get(0).getUniqueIdentifier(), resultEvents.get(1).getParentID());
 	}
 
 	@Test
@@ -1447,12 +1475,15 @@ public class EdgeFunctionalTests {
 		assertNetworkRequestCount();
 		assertExpectedEvents(false);
 
+		List<Event> requestEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.REQUEST_CONTENT);
+		assertEquals(1, requestEvents.size());
+
 		List<Event> resultEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(1, resultEvents.size());
 
 		Map<String, String> eventData = FunctionalTestUtils.flattenMap(resultEvents.get(0).getEventData());
 
-		assertEquals(10, eventData.size());
+		assertEquals(11, eventData.size());
 		assertEquals("422", eventData.get("status"));
 		assertEquals("https://ns.adobe.com/aep/errors/EXEG-0104-422", eventData.get("type"));
 		assertEquals("Unprocessable Entity", eventData.get("title"));
@@ -1468,29 +1499,8 @@ public class EdgeFunctionalTests {
 		);
 		assertEquals("0f8821e5-ed1a-4301-b445-5f336fb50ee8", eventData.get("report.requestId"));
 		assertEquals("test@AdobeOrg", eventData.get("report.orgId"));
-	}
-
-	// --------------------------------------------------------------------------------------------
-	// test chained event
-	// --------------------------------------------------------------------------------------------
-
-	@Test
-	public void testGetLocationHint_responseEventChainedToParentId() throws InterruptedException {
-		final CountDownLatch latch = new CountDownLatch(1);
-
-		Edge.setLocationHint("or2");
-		Edge.getLocationHint(s -> {
-			latch.countDown();
-		});
-
-		latch.await(2000, TimeUnit.MILLISECONDS);
-
-		List<Event> dispatchedRequests = getDispatchedEventsWith(EventType.EDGE, EventSource.REQUEST_IDENTITY);
-		assertEquals(1, dispatchedRequests.size());
-		List<Event> dispatchedResponses = getDispatchedEventsWith(EventType.EDGE, EventSource.RESPONSE_IDENTITY);
-		assertEquals(1, dispatchedResponses.size());
-
-		assertEquals(dispatchedRequests.get(0).getUniqueIdentifier(), dispatchedResponses.get(0).getParentID());
+		assertEquals(requestEvents.get(0).getUniqueIdentifier(), eventData.get("requestEventId"));
+		assertEquals(requestEvents.get(0).getUniqueIdentifier(), resultEvents.get(0).getParentID());
 	}
 
 	private void updateConfiguration(final Map<String, Object> config) throws InterruptedException {

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
@@ -1470,6 +1470,29 @@ public class EdgeFunctionalTests {
 		assertEquals("test@AdobeOrg", eventData.get("report.orgId"));
 	}
 
+	// --------------------------------------------------------------------------------------------
+	// test chained event
+	// --------------------------------------------------------------------------------------------
+
+	@Test
+	public void testGetLocationHint_responseEventChainedToParentId() throws InterruptedException {
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		Edge.setLocationHint("or2");
+		Edge.getLocationHint(s -> {
+			latch.countDown();
+		});
+
+		latch.await(2000, TimeUnit.MILLISECONDS);
+
+		List<Event> dispatchedRequests = getDispatchedEventsWith(EventType.EDGE, EventSource.REQUEST_IDENTITY);
+		assertEquals(1, dispatchedRequests.size());
+		List<Event> dispatchedResponses = getDispatchedEventsWith(EventType.EDGE, EventSource.RESPONSE_IDENTITY);
+		assertEquals(1, dispatchedResponses.size());
+
+		assertEquals(dispatchedRequests.get(0).getUniqueIdentifier(), dispatchedResponses.get(0).getParentID());
+	}
+
 	private void updateConfiguration(final Map<String, Object> config) throws InterruptedException {
 		final CountDownLatch latch = new CountDownLatch(1);
 		MobileCore.updateConfiguration(config);

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
@@ -122,7 +122,7 @@ public class NetworkResponseHandlerFunctionalTests {
 	}
 
 	@Test
-	public void testProcessResponseOnError_WhenGenericJsonError_noWaitingEvents_dispatchesEvent()
+	public void testProcessResponseOnError_WhenGenericJsonError_noMatchingEvents_dispatchesEvent()
 		throws InterruptedException {
 		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
 		final String jsonError =
@@ -130,6 +130,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			"\"type\": \"https://ns.adobe.com/aep/errors/EXEG-0201-503\",\n" +
 			"\"title\": \"Request to Data platform failed with an unknown exception\"" +
 			"\n}";
+		networkResponseHandler.addWaitingEvent("abc", event1); // Request ID does not match
 		networkResponseHandler.processResponseOnError(jsonError, "123");
 		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 5000);
 		assertEquals(1, dispatchEvents.size());

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
@@ -393,7 +393,11 @@ class NetworkResponseHandler {
 			.build();
 
 		if (responseEvent.getParentID() == null) {
-			Log.debug(LOG_TAG, LOG_SOURCE, "dispatchResponse - Parent Event is null, dispatching response event without chained parent.");
+			Log.debug(
+				LOG_TAG,
+				LOG_SOURCE,
+				"dispatchResponse - Parent Event is null, dispatching response event without chained parent."
+			);
 		}
 
 		MobileCore.dispatchEvent(responseEvent);

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
@@ -392,6 +392,10 @@ class NetworkResponseHandler {
 			.setParentId(parentId)
 			.build();
 
+		if (responseEvent.getParentID() == null) {
+			Log.debug(LOG_TAG, LOG_SOURCE, "dispatchResponse - Parent Event is null, dispatching response event without chained parent.");
+		}
+
 		MobileCore.dispatchEvent(responseEvent);
 	}
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -28,7 +28,7 @@ mavenRepoDescription=Adobe Experience Platform Edge extension for the Adobe Expe
 mavenUploadDryRunFlag=false
 
 # production versions for production build
-mavenCoreVersion=2.0.0
+mavenCoreVersion=2.2.0
 mavenIdentityVersion=2.0.0
 androidxAnnotationVersion=1.0.0
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Set parent ID to response events dispatched from NetworkResponseHandler. Parent ID is taken from events in `sentEventsWaitingResponse`, so if response request ID or event index does not match an Event in the list the dispatched event will have a null parentID.

Response events for `Edge.getLocationHint()` already contain the parent ID (via Event.Builder.inResponseToEvent() api), so no code changes needed. Added tests to verify parentId in location hint response.

Updates Mobile Core dependency to 2.2.0, which adds support for chaining events.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
