### PR TITLE
Set parent ID to Edge response events (#69)

### DIFF
--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
@@ -122,13 +122,15 @@ public class NetworkResponseHandlerFunctionalTests {
 	}
 
 	@Test
-	public void testProcessResponseOnError_WhenGenericJsonError_dispatchesEvent() throws InterruptedException {
+	public void testProcessResponseOnError_WhenGenericJsonError_noMatchingEvents_dispatchesEvent()
+		throws InterruptedException {
 		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
 		final String jsonError =
 			"{\n" +
 			"\"type\": \"https://ns.adobe.com/aep/errors/EXEG-0201-503\",\n" +
 			"\"title\": \"Request to Data platform failed with an unknown exception\"" +
 			"\n}";
+		networkResponseHandler.addWaitingEvent("abc", event1); // Request ID does not match
 		networkResponseHandler.processResponseOnError(jsonError, "123");
 		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 5000);
 		assertEquals(1, dispatchEvents.size());
@@ -138,6 +140,31 @@ public class NetworkResponseHandlerFunctionalTests {
 		assertEquals("https://ns.adobe.com/aep/errors/EXEG-0201-503", flattenReceivedData.get("type"));
 		assertEquals("Request to Data platform failed with an unknown exception", flattenReceivedData.get("title"));
 		assertEquals("123", flattenReceivedData.get("requestId"));
+		assertNull(flattenReceivedData.get("requestEventId"));
+		assertNull(dispatchEvents.get(0).getParentID());
+	}
+
+	@Test
+	public void testProcessResponseOnError_WhenGenericJsonError_dispatchesEventChainedToParentEvent()
+		throws InterruptedException {
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
+		final String jsonError =
+			"{\n" +
+			"\"type\": \"https://ns.adobe.com/aep/errors/EXEG-0201-503\",\n" +
+			"\"title\": \"Request to Data platform failed with an unknown exception\"" +
+			"\n}";
+		networkResponseHandler.addWaitingEvent("123", event1);
+		networkResponseHandler.processResponseOnError(jsonError, "123");
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 5000);
+		assertEquals(1, dispatchEvents.size());
+
+		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
+		assertEquals(4, flattenReceivedData.size());
+		assertEquals("https://ns.adobe.com/aep/errors/EXEG-0201-503", flattenReceivedData.get("type"));
+		assertEquals("Request to Data platform failed with an unknown exception", flattenReceivedData.get("title"));
+		assertEquals("123", flattenReceivedData.get("requestId"));
+		assertEquals(event1.getUniqueIdentifier(), flattenReceivedData.get("requestEventId"));
+		assertEquals(event1.getUniqueIdentifier(), dispatchEvents.get(0).getParentID());
 	}
 
 	@Test
@@ -168,6 +195,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			flattenReceivedData.get("title")
 		);
 		assertEquals("123", flattenReceivedData.get("requestId"));
+		assertNull(dispatchEvents.get(0).getParentID());
 	}
 
 	@Test
@@ -183,7 +211,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			"          \"status\": 100,\n" +
 			"          \"type\": \"personalization\",\n" +
 			"          \"title\": \"Button color not found\",\n" +
-			"           \"eventIndex\": 0\n" +
+			"           \"eventIndex\": 1\n" +
 			"        }\n" +
 			"      ]\n" +
 			"    }";
@@ -205,9 +233,10 @@ public class NetworkResponseHandlerFunctionalTests {
 		assertEquals("personalization", flattenReceivedData.get("type"));
 		assertEquals("100", flattenReceivedData.get("status"));
 		assertEquals("Button color not found", flattenReceivedData.get("title"));
-		assertEquals("0", flattenReceivedData.get("eventIndex"));
+		assertEquals("1", flattenReceivedData.get("eventIndex"));
 		assertEquals(requestId, flattenReceivedData.get("requestId"));
-		assertEquals(event1.getUniqueIdentifier(), flattenReceivedData.get("requestEventId"));
+		assertEquals(event2.getUniqueIdentifier(), flattenReceivedData.get("requestEventId"));
+		assertEquals(event2.getUniqueIdentifier(), dispatchEvents.get(0).getParentID());
 	}
 
 	@Test
@@ -247,6 +276,7 @@ public class NetworkResponseHandlerFunctionalTests {
 		assertEquals("Button color not found", flattenReceivedData.get("title"));
 		assertEquals("10", flattenReceivedData.get("eventIndex"));
 		assertEquals(requestId, flattenReceivedData.get("requestId"));
+		assertNull(dispatchEvents.get(0).getParentID());
 	}
 
 	@Test
@@ -286,6 +316,7 @@ public class NetworkResponseHandlerFunctionalTests {
 		assertEquals("Button color not found", flattenReceivedData.get("title"));
 		assertEquals("0", flattenReceivedData.get("eventIndex"));
 		assertEquals("567", flattenReceivedData.get("requestId"));
+		assertNull(dispatchEvents.get(0).getParentID());
 	}
 
 	@Test
@@ -309,12 +340,13 @@ public class NetworkResponseHandlerFunctionalTests {
 			"        }\n" +
 			"      ]\n" +
 			"    }";
+		networkResponseHandler.addWaitingEvent(requestId, event1);
 		networkResponseHandler.processResponseOnError(jsonError, requestId);
 		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(2, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData1 = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
-		assertEquals(4, flattenReceivedData1.size());
+		assertEquals(5, flattenReceivedData1.size());
 		assertEquals("0", flattenReceivedData1.get("status"));
 		assertEquals("https://ns.adobe.com/aep/errors/EXEG-0201-503", flattenReceivedData1.get("type"));
 		assertEquals(
@@ -322,13 +354,17 @@ public class NetworkResponseHandlerFunctionalTests {
 			flattenReceivedData1.get("title")
 		);
 		assertEquals(requestId, flattenReceivedData1.get("requestId"));
+		assertEquals(event1.getUniqueIdentifier(), flattenReceivedData1.get("requestEventId"));
+		assertEquals(event1.getUniqueIdentifier(), dispatchEvents.get(0).getParentID());
 
 		Map<String, String> flattenReceivedData2 = FunctionalTestUtils.flattenMap(dispatchEvents.get(1).getEventData());
-		assertEquals(4, flattenReceivedData2.size());
+		assertEquals(5, flattenReceivedData2.size());
 		assertEquals("2003", flattenReceivedData2.get("status"));
 		assertEquals("personalization", flattenReceivedData2.get("type"));
 		assertEquals("Failed to process personalization event", flattenReceivedData2.get("title"));
 		assertEquals(requestId, flattenReceivedData2.get("requestId"));
+		assertEquals(event1.getUniqueIdentifier(), flattenReceivedData2.get("requestEventId"));
+		assertEquals(event1.getUniqueIdentifier(), dispatchEvents.get(1).getParentID());
 	}
 
 	// ---------------------------------------------------------------------------------------------
@@ -371,18 +407,21 @@ public class NetworkResponseHandlerFunctionalTests {
 			"        }],\n" +
 			"      \"errors\": []\n" +
 			"    }";
+		networkResponseHandler.addWaitingEvent("123", event1);
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, "123");
 
 		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, "state:store");
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
-		assertEquals(5, flattenReceivedData.size());
+		assertEquals(6, flattenReceivedData.size());
 		assertEquals("state:store", flattenReceivedData.get("type"));
 		assertEquals("123", flattenReceivedData.get("requestId"));
 		assertEquals("s_ecid", flattenReceivedData.get("payload[0].key"));
 		assertEquals("MCMID|29068398647607325310376254630528178721", flattenReceivedData.get("payload[0].value"));
 		assertEquals("15552000", flattenReceivedData.get("payload[0].maxAge"));
+		assertEquals(event1.getUniqueIdentifier(), flattenReceivedData.get("requestEventId"));
+		assertEquals(event1.getUniqueIdentifier(), dispatchEvents.get(0).getParentID());
 	}
 
 	@Test
@@ -493,6 +532,7 @@ public class NetworkResponseHandlerFunctionalTests {
 		assertEquals("s_ecid", flattenReceivedData1.get("payload[0].key"));
 		assertEquals("MCMID|29068398647607325310376254630528178721", flattenReceivedData1.get("payload[0].value"));
 		assertEquals("15552000", flattenReceivedData1.get("payload[0].maxAge"));
+		assertNull(dispatchEvents.get(0).getParentID());
 
 		// verify event 2
 		Map<String, String> flattenReceivedData2 = FunctionalTestUtils.flattenMap(dispatchEvents.get(1).getEventData());
@@ -501,6 +541,7 @@ public class NetworkResponseHandlerFunctionalTests {
 		assertEquals("123", flattenReceivedData2.get("requestId"));
 		assertEquals("29068398647607325310376254630528178721", flattenReceivedData2.get("payload[0].id"));
 		assertEquals("ECID", flattenReceivedData2.get("payload[0].namespace.code"));
+		assertNull(dispatchEvents.get(1).getParentID());
 	}
 
 	@Test
@@ -556,6 +597,7 @@ public class NetworkResponseHandlerFunctionalTests {
 		assertEquals("15552000", flattenReceivedData1.get("payload[0].maxAge"));
 		assertEquals("123", flattenReceivedData1.get("requestId"));
 		assertEquals(event1.getUniqueIdentifier(), flattenReceivedData1.get("requestEventId"));
+		assertEquals(event1.getUniqueIdentifier(), dispatchEvents.get(0).getParentID());
 
 		// verify event 2
 		Map<String, String> flattenReceivedData2 = FunctionalTestUtils.flattenMap(dispatchEvents.get(1).getEventData());
@@ -564,6 +606,7 @@ public class NetworkResponseHandlerFunctionalTests {
 		assertEquals("123612123812381", flattenReceivedData2.get("payload[0].id"));
 		assertEquals("123", flattenReceivedData2.get("requestId"));
 		assertEquals(event2.getUniqueIdentifier(), flattenReceivedData2.get("requestEventId"));
+		assertEquals(event2.getUniqueIdentifier(), dispatchEvents.get(1).getParentID());
 	}
 
 	@Test
@@ -606,6 +649,7 @@ public class NetworkResponseHandlerFunctionalTests {
 		assertEquals("pairedeventexample", flattenReceivedData.get("type"));
 		assertEquals("123", flattenReceivedData.get("requestId"));
 		assertEquals("123612123812381", flattenReceivedData.get("payload[0].id"));
+		assertNull(dispatchEvents.get(0).getParentID());
 	}
 
 	@Test
@@ -647,6 +691,7 @@ public class NetworkResponseHandlerFunctionalTests {
 		assertEquals("pairedeventexample", flattenReceivedData.get("type"));
 		assertEquals("123", flattenReceivedData.get("requestId"));
 		assertEquals("123612123812381", flattenReceivedData.get("payload[0].id"));
+		assertNull(dispatchEvents.get(0).getParentID());
 	}
 
 	// ---------------------------------------------------------------------------------------------
@@ -680,18 +725,21 @@ public class NetworkResponseHandlerFunctionalTests {
 			"       ]\n" +
 			"    }";
 
+		networkResponseHandler.addWaitingEvents(requestId, Arrays.asList(event1, event2));
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, requestId);
 
 		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, "state:store");
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData1 = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
-		assertEquals(5, flattenReceivedData1.size());
+		assertEquals(6, flattenReceivedData1.size());
 		assertEquals("state:store", flattenReceivedData1.get("type"));
 		assertEquals("123", flattenReceivedData1.get("requestId"));
 		assertEquals("s_ecid", flattenReceivedData1.get("payload[0].key"));
 		assertEquals("MCMID|29068398647607325310376254630528178721", flattenReceivedData1.get("payload[0].value"));
 		assertEquals("15552000", flattenReceivedData1.get("payload[0].maxAge"));
+		assertEquals(event1.getUniqueIdentifier(), flattenReceivedData1.get("requestEventId"));
+		assertEquals(event1.getUniqueIdentifier(), dispatchEvents.get(0).getParentID());
 
 		List<Event> dispatchErrorEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(1, dispatchErrorEvents.size());
@@ -699,11 +747,13 @@ public class NetworkResponseHandlerFunctionalTests {
 		Map<String, String> flattenReceivedData2 = FunctionalTestUtils.flattenMap(
 			dispatchErrorEvents.get(0).getEventData()
 		);
-		assertEquals(4, flattenReceivedData2.size());
+		assertEquals(5, flattenReceivedData2.size());
 		assertEquals("personalization", flattenReceivedData2.get("type"));
 		assertEquals("2003", flattenReceivedData2.get("status"));
 		assertEquals("Failed to process personalization event", flattenReceivedData2.get("title"));
 		assertEquals("123", flattenReceivedData2.get("requestId"));
+		assertEquals(event1.getUniqueIdentifier(), flattenReceivedData2.get("requestEventId"));
+		assertEquals(event1.getUniqueIdentifier(), dispatchErrorEvents.get(0).getParentID());
 	}
 
 	@Test
@@ -718,7 +768,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			"        {\n" +
 			"          \"status\": 2003,\n" +
 			"          \"title\": \"Failed to process personalization event\",\n" +
-			"          \"eventIndex\": 2 \n" +
+			"          \"eventIndex\": 1 \n" +
 			"        }\n" +
 			"       ],\n" +
 			"      \"warnings\": [" +
@@ -726,7 +776,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			"          \"type\": \"https://ns.adobe.com/aep/errors/EXEG-0204-200\",\n" +
 			"          \"status\": 98,\n" +
 			"          \"title\": \"Some Informative stuff here\",\n" +
-			"          \"eventIndex\": 10, \n" +
+			"          \"eventIndex\": 0, \n" +
 			"          \"report\": {" +
 			"             \"cause\": {" +
 			"                \"message\": \"Some Informative stuff here\",\n" +
@@ -737,27 +787,32 @@ public class NetworkResponseHandlerFunctionalTests {
 			"       ]\n" +
 			"    }";
 
+		networkResponseHandler.addWaitingEvents(requestId, Arrays.asList(event1, event2));
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, requestId);
 
 		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
 		assertEquals(2, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData1 = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
-		assertEquals(4, flattenReceivedData1.size());
+		assertEquals(5, flattenReceivedData1.size());
 		assertEquals("2003", flattenReceivedData1.get("status"));
 		assertEquals("Failed to process personalization event", flattenReceivedData1.get("title"));
-		assertEquals("2", flattenReceivedData1.get("eventIndex"));
+		assertEquals("1", flattenReceivedData1.get("eventIndex"));
 		assertEquals("123", flattenReceivedData1.get("requestId"));
+		assertEquals(event2.getUniqueIdentifier(), flattenReceivedData1.get("requestEventId"));
+		assertEquals(event2.getUniqueIdentifier(), dispatchEvents.get(0).getParentID());
 
 		Map<String, String> flattenReceivedData2 = FunctionalTestUtils.flattenMap(dispatchEvents.get(1).getEventData());
-		assertEquals(7, flattenReceivedData2.size());
+		assertEquals(8, flattenReceivedData2.size());
 		assertEquals("https://ns.adobe.com/aep/errors/EXEG-0204-200", flattenReceivedData2.get("type"));
 		assertEquals("98", flattenReceivedData2.get("status"));
 		assertEquals("Some Informative stuff here", flattenReceivedData2.get("title"));
 		assertEquals("Some Informative stuff here", flattenReceivedData2.get("report.cause.message"));
 		assertEquals("202", flattenReceivedData2.get("report.cause.code"));
-		assertEquals("10", flattenReceivedData2.get("eventIndex"));
+		assertEquals("0", flattenReceivedData2.get("eventIndex"));
 		assertEquals("123", flattenReceivedData2.get("requestId"));
+		assertEquals(event1.getUniqueIdentifier(), flattenReceivedData2.get("requestEventId"));
+		assertEquals(event1.getUniqueIdentifier(), dispatchEvents.get(1).getParentID());
 	}
 
 	// ---------------------------------------------------------------------------------------------
@@ -788,13 +843,14 @@ public class NetworkResponseHandlerFunctionalTests {
 			"            ]\n" +
 			"        }]\n" +
 			"    }";
+		networkResponseHandler.addWaitingEvent("123", event1);
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, "123");
 
 		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, "locationHint:result");
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());
-		assertEquals(8, flattenReceivedData.size());
+		assertEquals(9, flattenReceivedData.size());
 		assertEquals("locationHint:result", flattenReceivedData.get("type"));
 		assertEquals("123", flattenReceivedData.get("requestId"));
 		assertEquals("EdgeNetwork", flattenReceivedData.get("payload[0].scope"));
@@ -803,6 +859,8 @@ public class NetworkResponseHandlerFunctionalTests {
 		assertEquals("Target", flattenReceivedData.get("payload[1].scope"));
 		assertEquals("edge34", flattenReceivedData.get("payload[1].hint"));
 		assertEquals("600", flattenReceivedData.get("payload[1].ttlSeconds"));
+		assertEquals(event1.getUniqueIdentifier(), flattenReceivedData.get("requestEventId"));
+		assertEquals(event1.getUniqueIdentifier(), dispatchEvents.get(0).getParentID());
 	}
 
 	@Test

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
@@ -277,20 +277,9 @@ class NetworkResponseHandler {
 				}
 			} else {
 				// generic server error, return the error as is
-				Map<String, Object> eventDataResponse = JSONUtils.toMap(json);
-				if (eventDataResponse == null) {
-					return;
-				}
-
-				eventDataResponse.put(EdgeConstants.EventDataKeys.EDGE_REQUEST_ID, requestId);
-				Event responseEvent = new Event.Builder(
-					EdgeConstants.EventName.ERROR_RESPONSE_CONTENT,
-					EventType.EDGE,
-					EventSource.ERROR_RESPONSE_CONTENT
-				)
-					.setEventData(eventDataResponse)
-					.build();
-				MobileCore.dispatchEvent(responseEvent);
+				JSONArray errorsArray = new JSONArray();
+				errorsArray.put(json);
+				dispatchEventErrors(errorsArray, true, requestId);
 			}
 		} catch (JSONException e) {
 			Log.warning(
@@ -372,7 +361,7 @@ class NetworkResponseHandler {
 	/**
 	 * Dispatches a new event with the provided {@code eventData} as responseContent or as errorResponseContent based on the {@code isError} setting
 	 * @param eventData Event data to be dispatched, should not be empty
-	 * @param requestId The request identifier associated with this response event, used for logging
+	 * @param parentId The triggering parent event identifier associated with this response event
 	 * @param isError indicates if this should be dispatched as an error or regular response content event
 	 * @param eventSource an optional {@link String} to be used as the event source.
 	 *        If {@code eventSource} is nil, either {@link EventSource#ERROR_RESPONSE_CONTENT} or
@@ -380,7 +369,7 @@ class NetworkResponseHandler {
 	 */
 	private void dispatchResponse(
 		final Map<String, Object> eventData,
-		final String requestId,
+		final String parentId,
 		final boolean isError,
 		final String eventSource
 	) {
@@ -400,7 +389,16 @@ class NetworkResponseHandler {
 			source
 		)
 			.setEventData(eventData)
+			.setParentId(parentId)
 			.build();
+
+		if (responseEvent.getParentID() == null) {
+			Log.debug(
+				LOG_TAG,
+				LOG_SOURCE,
+				"dispatchResponse - Parent Event is null, dispatching response event without chained parent."
+			);
+		}
 
 		MobileCore.dispatchEvent(responseEvent);
 	}
@@ -430,7 +428,7 @@ class NetworkResponseHandler {
 		final String eventSource
 	) {
 		addEventAndRequestIdToData(eventData, requestId, eventId);
-		dispatchResponse(eventData, requestId, false, eventSource);
+		dispatchResponse(eventData, eventId, false, eventSource);
 	}
 
 	/**
@@ -556,7 +554,7 @@ class NetworkResponseHandler {
 
 			// set eventRequestId and edge requestId on the response event and dispatch data
 			addEventAndRequestIdToData(eventDataResponse, requestId, eventId);
-			dispatchResponse(eventDataResponse, requestId, true, null);
+			dispatchResponse(eventDataResponse, eventId, true, null);
 		}
 	}
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -28,7 +28,7 @@ mavenRepoDescription=Adobe Experience Platform Edge extension for the Adobe Expe
 mavenUploadDryRunFlag=false
 
 # production versions for production build
-mavenCoreVersion=2.0.0
+mavenCoreVersion=2.2.0
 mavenIdentityVersion=2.0.0
 androidxAnnotationVersion=1.0.0
 


### PR DESCRIPTION
* Set Core dependency to 2.2.0 which adds support for chaining events

* Add functional test to assert getLocationHint response event chained to request event

* Set parentId for events dispatched from NetworkResponseHandler

* Add functional tests for parentId set in response events

* Update test case with real-world use case

* Add log message when dispatching response Event without parent id

* Make format to fix indentations

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
