### PR TITLE
Fix warnings in Gradle files

### DIFF
--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -76,6 +76,6 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.9'
 }
 
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
 }

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -44,7 +44,7 @@ ext {
     jacocoVersion = "0.8.8"
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }
 
@@ -55,7 +55,7 @@ license {
 }
 
 // Add and maintain licence header to all project files of type XML, YAML, Properties, and Gradle
-task licenseFormatProject(type: LicenseFormat) {
+tasks.register('licenseFormatProject', LicenseFormat) {
     source = fileTree(dir: "../")
             .exclude(["**/.idea/*", "**/build/*", "**/*.java", "**/*.kt", "**/.git/*", "**/.gradle/*", "**/gradle/wrapper/*", "config/*", "**/local.properties"])
             .include(["**/*.xml", "**/*.yml", "**/*.properties", "**/*.gradle"])

--- a/code/edge/build.gradle
+++ b/code/edge/build.gradle
@@ -33,7 +33,7 @@ android {
         testInstrumentationRunner rootProject.ext.testInstrumentationRunner
     }
 
-    flavorDimensions "target"
+    flavorDimensions = ["target"]
     productFlavors {
         phone {
             dimension "target"

--- a/code/edge/build.gradle
+++ b/code/edge/build.gradle
@@ -77,30 +77,32 @@ spotless {
 }
 
 afterEvaluate {
-    tasks.withType(Javadoc) {
-        source = android.sourceSets.main.java.srcDirs
-        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-        classpath += files(android.libraryVariants.collect { variant ->
-            variant.javaCompileProvider.get().classpath.files
-        })
-        options {
-            source = "8"
-            links "https://developer.android.com/reference"
+    tasks.withType(Javadoc).tap {
+        configureEach {
+            source = android.sourceSets.main.java.srcDirs
+            classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+            classpath += files(android.libraryVariants.collect { variant ->
+                variant.javaCompileProvider.get().classpath.files
+            })
+            options {
+                source = "8"
+                links "https://developer.android.com/reference"
+            }
         }
     }
 }
 
-task javadocInternal(type: Javadoc) {
+tasks.register('javadocInternal', Javadoc) {
     destinationDir = reporting.file("javadocInternal")
     options.memberLevel = JavadocMemberLevel.PRIVATE
 }
 
-task javadocPublic(type: Javadoc) {
+tasks.register('javadocPublic', Javadoc) {
     destinationDir = reporting.file("javadocPublic")
     options.memberLevel = JavadocMemberLevel.PUBLIC
 }
 
-task javadocPublish(type: Jar) {
+tasks.register('javadocPublish', Jar) {
     from javadocPublic
     archiveClassifier.set('javadoc')
 }
@@ -146,7 +148,7 @@ publishing {
                     url = 'https://github.com/adobe/aepsdk-edge-android'
                 }
                 withXml {
-                    def dependenciesNode = asNode().appendNode('dependencies')
+                    def dependenciesNode = asNode(null).appendNode('dependencies')
 
                     def coreDependencyNode = dependenciesNode.appendNode('dependency')
                     coreDependencyNode.appendNode('groupId', 'com.adobe.marketing.mobile')
@@ -187,13 +189,14 @@ signing {
     sign publishing.publications
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     testLogging {
         showStandardStreams = true
     }
 }
 
-task platformUnitTestJacocoReport(type: JacocoReport, dependsOn: "testPhoneDebugUnitTest") {
+tasks.register('platformUnitTestJacocoReport', JacocoReport) {
+    dependsOn "testPhoneDebugUnitTest"
     def excludeRegex = ['**/BuildConfig.class']
     def debugTree = fileTree(dir: "${project.buildDir}/intermediates/javac/phoneDebug/classes/com/adobe/marketing/mobile", excludes: excludeRegex)
 
@@ -212,7 +215,8 @@ task platformUnitTestJacocoReport(type: JacocoReport, dependsOn: "testPhoneDebug
     }
 }
 
-task platformFunctionalTestJacocoReport(type: JacocoReport, dependsOn: "createPhoneDebugCoverageReport") {
+tasks.register('platformFunctionalTestJacocoReport', JacocoReport) {
+    dependsOn "createPhoneDebugCoverageReport"
     def excludeRegex = ['**/BuildConfig.class']
     def debugTree = fileTree(dir: "${project.buildDir}/intermediates/javac/phoneDebug/classes/com/adobe/marketing/mobile", excludes: excludeRegex)
 
@@ -231,7 +235,7 @@ task platformFunctionalTestJacocoReport(type: JacocoReport, dependsOn: "createPh
     }
 }
 
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix warnings listed in Gradle files by Android Studio when running Inspect Code.

- Fix use of deprecated `flavorDimensions`
- Use `tasks.register` instead of `task` to reduce configuration time.
- Use `configureEach` instead of `all` to reduce configuration time.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
