### PR TITLE
Dispatch 'complete' event when streaming connection closed

### DIFF
--- a/Documentation/event-reference.md
+++ b/Documentation/event-reference.md
@@ -213,7 +213,7 @@ The Edge Network response handle type is used as the event source for this event
 
 | Event type | Event source |
 | ---------- | ------------ |
-| com.adobe.eventType.edge | defined by response handle type, or com.adobe.eventSource.responseContent |
+| com.adobe.eventType.edge | Defined by response handle type, or com.adobe.eventSource.responseContent |
 
 #### Event data payload definition<!-- omit in toc -->
 

--- a/Documentation/event-reference.md
+++ b/Documentation/event-reference.md
@@ -218,6 +218,22 @@ This event does not have standard keys.
 
 -----
 
+### Edge content complete
+
+This event is a response to an [Edge request content](#edge-request-content) event and is sent when the Edge Network request is complete. This event is only dispatched when requested by the request content event.
+
+#### Event details<!-- omit in toc -->
+
+| Event type | Event source |
+| ---------- | ------------ |
+| com.adobe.eventType.edge | com.adobe.eventSource.contentComplete |
+
+#### Event data payload definition<!-- omit in toc -->
+
+| Key | Value type | Required | Description |
+| --- | ---------- | -------- | ----------- |
+| requestId | `String` | Yes | The ID (`UUID`) of the batched Edge Network request tied to the event that requested the completion response. |
+
 ### Edge state store
 
 This event tells the Edge Network extension to persist the event payload to the data store. This event is constructed using the response fragment from the Edge Network service for a sent XDM Experience Event; Edge Network extension does not modify any values received and constructs a response event with the event source and data payload as-is.

--- a/Documentation/event-reference.md
+++ b/Documentation/event-reference.md
@@ -41,6 +41,7 @@ If the required `xdm` key is not present in the event data payload, the event is
 | xdm | <code>Map<String,&nbsp;Object></code> | Yes | XDM formatted data; use an `XDMSchema` implementation for better XDM data ingestion and data format control. |
 | data | <code>Map<String,&nbsp;Object></code> | No | Optional free-form data associated with this event. |
 | datasetId | `String` | No | Optional custom dataset ID. If not set, the event uses the default Experience dataset ID set in the datastream configuration. |
+| request | <code>Map<String,&nbsp;Object></code> | No | Optional request parameters. |
 
 > **Note**  
 > Events of this type and source are only processed if the data collection consent status stored in the `collect` property is **not** `n` (no); that is, either `y` (yes) or `p` (pending).
@@ -204,13 +205,15 @@ This event is an error response to an originating event. If there are multiple e
 
 ### Edge response content
 
-This event is a response to an [Edge request content](#edge-request-content) event.
+This event is a response to an [Edge request content](#edge-request-content) event. The data payload of this event contains a response handle from the Edge Network. If there are multiple response handles, separate response event instances are dispatched for each.
 
 #### Event details<!-- omit in toc -->
 
+The Edge Network response handle type is used as the event source for this event. If the handle does not define a type, then `com.adobe.eventSource.responseContent` is used as a fallback.
+
 | Event type | Event source |
 | ---------- | ------------ |
-| com.adobe.eventType.edge | com.adobe.eventSource.responseContent |
+| com.adobe.eventType.edge | defined by response handle type, or com.adobe.eventSource.responseContent |
 
 #### Event data payload definition<!-- omit in toc -->
 
@@ -220,7 +223,7 @@ This event does not have standard keys.
 
 ### Edge content complete
 
-This event is a response to an [Edge request content](#edge-request-content) event and is sent when the Edge Network request is complete. This event is only dispatched when requested by the request content event.
+This event is a response to an [Edge request content](#edge-request-content) event and is sent when the Edge Network request is complete. This event is only dispatched when requested by the request content event when the `request` payload object contains the property `sendCompletion` with boolean value `true`.
 
 #### Event details<!-- omit in toc -->
 

--- a/code/app-kotlin/src/main/java/com/adobe/marketing/tester/app/MainActivity.kt
+++ b/code/app-kotlin/src/main/java/com/adobe/marketing/tester/app/MainActivity.kt
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.tester.app
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
@@ -18,9 +19,14 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.*
 import androidx.appcompat.app.AppCompatActivity
+import com.adobe.marketing.mobile.AdobeCallbackWithError
+import com.adobe.marketing.mobile.AdobeError
 import com.adobe.marketing.mobile.Assurance
 import com.adobe.marketing.mobile.Edge
 import com.adobe.marketing.mobile.EdgeEventHandle
+import com.adobe.marketing.mobile.Event
+import com.adobe.marketing.mobile.EventSource
+import com.adobe.marketing.mobile.EventType
 import com.adobe.marketing.mobile.ExperienceEvent
 import com.adobe.marketing.mobile.MobileCore
 import com.adobe.marketing.mobile.edge.consent.Consent
@@ -224,6 +230,35 @@ class MainActivity : AppCompatActivity() {
                 val textViewGetData: TextView = findViewById(R.id.tvGetData)
                 runOnUiThread{ textViewGetData.text = json }
             }
+        }
+
+        findViewById<Button>(R.id.btnSubmitCompleteEvent).setOnClickListener {
+            val eventData = mapOf<String, Any>(
+                    "xdm" to createCommerceXDM().serializeToXdm(),
+                    "request" to mapOf<String, Any>("sendCompletion" to true)
+            )
+
+            val event = Event.Builder("Edge Event Send Completion Request", EventType.EDGE, EventSource.REQUEST_CONTENT)
+                    .setEventData(eventData)
+                    .build()
+
+            MobileCore.dispatchEventWithResponseCallback(event, 2000L, object : AdobeCallbackWithError<Event?> {
+                @SuppressLint("SetTextI18n")
+                override fun call(completeEvent: Event?) {
+                    val textViewGetData: TextView = findViewById(R.id.tvGetData)
+                    runOnUiThread{
+                            textViewGetData.text = "Completion Event received: ${completeEvent?.eventData}"
+                    }
+                }
+
+                @SuppressLint("SetTextI18n")
+                override fun fail(error: AdobeError?) {
+                    val textViewGetData: TextView = findViewById(R.id.tvGetData)
+                    runOnUiThread {
+                        textViewGetData.text= "Dispatch Event Failed '${error?.errorName}"
+                    }
+                }
+            })
         }
     }
 

--- a/code/app-kotlin/src/main/res/layout/activity_main.xml
+++ b/code/app-kotlin/src/main/res/layout/activity_main.xml
@@ -91,6 +91,19 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/layout_request_environment" />
 
+    <Button
+        android:id="@+id/btnSubmitCompleteEvent"
+        android:layout_width="match_parent"
+        android:layout_height="45dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginHorizontal="10dp"
+        android:background="@color/colorPrimary"
+        android:text="@string/btn_dispatch_event"
+        android:textColor="@android:color/background_light"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btnSubmitSingleEvent" />
+
     <LinearLayout
         android:id="@+id/layout_location_hint"
         android:layout_width="match_parent"
@@ -100,7 +113,7 @@
         android:layout_marginHorizontal="10dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/btnSubmitSingleEvent"
+        app:layout_constraintTop_toBottomOf="@+id/btnSubmitCompleteEvent"
         >
 
         <Button

--- a/code/app-kotlin/src/main/res/values/strings.xml
+++ b/code/app-kotlin/src/main/res/values/strings.xml
@@ -37,4 +37,5 @@
     <string name="btn_assurance_connect">Connect</string>
     <string name="et_assurance_session_url_hint">Paste your Assurance session ID here</string>
     <string name="btn_assurance_settings_menu">Connect to Assurance</string>
+    <string name="btn_dispatch_event"><![CDATA[Dispach Event & Send Complete]]></string>
 </resources>

--- a/code/app/src/main/res/layout/activity_main.xml
+++ b/code/app/src/main/res/layout/activity_main.xml
@@ -94,6 +94,21 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/layout_request_environment" />
 
+    <Button
+        android:id="@+id/btnSubmitCompleteEvent"
+        android:layout_width="match_parent"
+        android:layout_height="45dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginHorizontal="10dp"
+        android:background="@color/colorPrimary"
+        android:onClick="onDispatchCompleteEvent"
+        android:text="@string/btn_dispatch_event"
+        android:textColor="@android:color/background_light"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btnSubmitSingleEvent" />
+
+
     <LinearLayout
         android:id="@+id/layout_location_hint"
         android:layout_width="match_parent"
@@ -103,7 +118,7 @@
         android:layout_marginHorizontal="10dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/btnSubmitSingleEvent"
+        app:layout_constraintTop_toBottomOf="@+id/btnSubmitCompleteEvent"
         >
 
         <Button

--- a/code/app/src/main/res/values/strings.xml
+++ b/code/app/src/main/res/values/strings.xml
@@ -32,4 +32,5 @@
     <string name="tv_mobile_core">Mobile Core</string>
     <string name="et_hint_assurance_id">Paste your Assurance session ID here</string>
     <string name="btn_connect_to_assurance">Connect to Assurance</string>
+    <string name="btn_dispatch_event"><![CDATA[Dispatch Event & Send Complete]]></string>
 </resources>

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -255,6 +256,72 @@ public class EdgeFunctionalTests {
 
 		// verify
 		assertUnexpectedEvents();
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// test complete event format
+	// --------------------------------------------------------------------------------------------
+
+	@Test
+	public void testDispatchEvent_sendCompleteEvent_sendsPairedCompleteEvent() throws InterruptedException {
+		Map<String, Object> eventData = new HashMap<String, Object>() {
+			{
+				put(
+					"xdm",
+					new HashMap<String, Object>() {
+						{
+							put("test", "data");
+						}
+					}
+				);
+				put(
+					"request",
+					new HashMap<String, Object>() {
+						{
+							put("sendCompletion", true);
+						}
+					}
+				);
+			}
+		};
+
+		Event edgeEvent = new Event.Builder(
+			"Edge Event Completion Request",
+			EventType.EDGE,
+			EventSource.REQUEST_CONTENT
+		)
+			.setEventData(eventData)
+			.build();
+
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		MobileCore.dispatchEventWithResponseCallback(
+			edgeEvent,
+			2000,
+			new AdobeCallbackWithError<Event>() {
+				@Override
+				public void fail(AdobeError adobeError) {
+					Assert.fail("DispatchEventWithResponseCallback returned an error: " + adobeError.toString());
+				}
+
+				@Override
+				public void call(Event event) {
+					assertEquals("AEP Response Complete", event.getName());
+					assertEquals(EventType.EDGE, event.getType());
+					assertEquals("com.adobe.eventSource.contentComplete", event.getSource()); // TODO use EventSource
+					assertEquals(edgeEvent.getUniqueIdentifier(), event.getParentID());
+					assertEquals(edgeEvent.getUniqueIdentifier(), event.getResponseID());
+					assertNotNull(event.getEventData());
+
+					Map<String, String> flattenedData = FunctionalTestUtils.flattenMap(event.getEventData());
+					assertEquals(1, flattenedData.size());
+					assertNotNull(flattenedData.get("requestId"));
+					latch.countDown();
+				}
+			}
+		);
+
+		assertTrue(latch.await(3000, TimeUnit.MILLISECONDS));
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
@@ -223,6 +223,24 @@ public class NetworkResponseHandlerFunctionalTests {
 	}
 
 	@Test
+	public void testProcessResponseOnError_WhenJsonErrorIncorrectType_doesNotHandleError() throws InterruptedException {
+		final String jsonError =
+			"{\n" +
+			"      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+			"      \"handle\": [],\n" +
+			"      \"errors\":\n" + // Json Array expected
+			"        {\n" +
+			"          \"status\": 500,\n" +
+			"          \"type\": \"https://ns.adobe.com/aep/errors/EXEG-0201-503\",\n" +
+			"          \"title\": \"Failed due to unrecoverable system error: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BEGIN_OBJECT at path $.commerce.purchases\"\n" +
+			"        }\n" +
+			"    }";
+		networkResponseHandler.processResponseOnError(jsonError, "123");
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
+		assertEquals(0, dispatchEvents.size());
+	}
+
+	@Test
 	public void testProcessResponseOnError_WhenValidEventIndex_dispatchesPairedEvent() throws InterruptedException {
 		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
 		final String requestId = "123";
@@ -399,8 +417,17 @@ public class NetworkResponseHandlerFunctionalTests {
 	// ---------------------------------------------------------------------------------------------
 
 	@Test
-	public void testProcessResponseOnSuccess_WhenEmptyJsonResponse_doesNotDispatchEvent() throws InterruptedException {
+	public void testProcessResponseOnSuccess_WhenEmptyStringResponse_doesNotDispatchEvent()
+		throws InterruptedException {
 		final String jsonResponse = "";
+		networkResponseHandler.processResponseOnSuccess(jsonResponse, "123");
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.RESPONSE_CONTENT);
+		assertEquals(0, dispatchEvents.size());
+	}
+
+	@Test
+	public void testProcessResponseOnSuccess_WhenEmptyJsonResponse_doesNotDispatchEvent() throws InterruptedException {
+		final String jsonResponse = "{}";
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, "123");
 		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.RESPONSE_CONTENT);
 		assertEquals(0, dispatchEvents.size());

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
@@ -23,7 +23,7 @@ final class EdgeConstants {
 
 		static final String REQUEST_CONTENT = "AEP Request Event";
 		static final String RESPONSE_CONTENT = "AEP Response Event Handle";
-		static final String RESPONSE_COMPLETE = "AEP Response Complete";
+		static final String CONTENT_COMPLETE = "AEP Response Complete";
 		static final String ERROR_RESPONSE_CONTENT = "AEP Error Response";
 		static final String REQUEST_LOCATION_HINT = "Edge Request Location Hint";
 		static final String RESPONSE_LOCATION_HINT = "Edge Location Hint Response";

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
@@ -23,6 +23,7 @@ final class EdgeConstants {
 
 		static final String REQUEST_CONTENT = "AEP Request Event";
 		static final String RESPONSE_CONTENT = "AEP Response Event Handle";
+		static final String RESPONSE_COMPLETE = "AEP Response Complete";
 		static final String ERROR_RESPONSE_CONTENT = "AEP Error Response";
 		static final String REQUEST_LOCATION_HINT = "Edge Request Location Hint";
 		static final String RESPONSE_LOCATION_HINT = "Edge Location Hint Response";
@@ -58,6 +59,8 @@ final class EdgeConstants {
 
 			static final String KEY = "request";
 			static final String PATH = "path";
+			// sendCompletion - boolean flag to determine if a "complete" event is requested
+			static final String SEND_COMPLETION = "sendCompletion";
 
 			private Request() {}
 		}

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
@@ -138,14 +138,7 @@ class EdgeHitProcessor implements HitProcessing {
 
 			@Override
 			public void onComplete() {
-				List<String> removedWaitingEvents = networkResponseHandler.removeWaitingEvents(edgeHit.getRequestId());
-
-				// unregister currently known completion callbacks
-				if (removedWaitingEvents != null) {
-					for (String eventId : removedWaitingEvents) {
-						CompletionCallbacksManager.getInstance().unregisterCallback(eventId);
-					}
-				}
+				networkResponseHandler.processResponseOnComplete(edgeHit.getRequestId());
 			}
 		};
 

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
@@ -297,7 +297,7 @@ class NetworkResponseHandler {
 					addEventAndRequestIdToData(eventData, requestId, null);
 
 					Event responseEvent = new Event.Builder(
-						EdgeConstants.EventName.RESPONSE_COMPLETE,
+						EdgeConstants.EventName.CONTENT_COMPLETE,
 						EventType.EDGE,
 						"com.adobe.eventSource.contentComplete" // TODO replace with EventSource constant
 					)

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
@@ -312,10 +312,11 @@ class NetworkResponseHandler {
 	}
 
 	/**
-	 * Extracts the boolean value of {@code request.sendCompletion} to determine if the given
-	 * {@code event} has requested a completion event.
-	 * @param event the {@code Event} to determine if a completion event is requested
-	 * @return true if a completion event is requested for the {@code event}, false if no completion event is requested.
+	 * Determines whether a completion event has been requested based on the boolean value of
+	 * {@code request.sendCompletion} in the provided {@code event}.
+	 *
+	 * @param event The {@code Event} whose data is checked for a completion event request.
+	 * @return true if the {@code event} is requesting a completion event; false otherwise.
 	 */
 	private boolean sendCompletionRequested(final Event event) {
 		Map<String, Object> eventData = event.getEventData();

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
@@ -22,6 +22,7 @@ import com.adobe.marketing.mobile.util.MapUtils;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,7 +41,7 @@ class NetworkResponseHandler {
 	private static final String LOG_SOURCE = "NetworkResponseHandler";
 
 	// the order of the request events matter for matching them with the response events
-	private final ConcurrentMap<String, List<WaitingEventContext>> sentEventsWaitingResponse;
+	private final ConcurrentMap<String, List<Event>> sentEventsWaitingResponse;
 	private final Object mutex = new Object();
 	private final NamedCollection namedCollection;
 	private final EdgeStateCallback edgeStateCallback;
@@ -83,13 +84,7 @@ class NetworkResponseHandler {
 			return;
 		}
 
-		final List<WaitingEventContext> eventContexts = new ArrayList<>();
-
-		for (Event e : batchedEvents) {
-			eventContexts.add(new WaitingEventContext(e.getUniqueIdentifier(), e.getTimestamp()));
-		}
-
-		if (sentEventsWaitingResponse.put(requestId, eventContexts) != null) {
+		if (sentEventsWaitingResponse.put(requestId, batchedEvents) != null) {
 			Log.warning(
 				LOG_TAG,
 				LOG_SOURCE,
@@ -116,27 +111,16 @@ class NetworkResponseHandler {
 	 * Remove the requestId in the internal {@code sentEventsWaitingResponse} along with the associated list of events.
 	 *
 	 * @param requestId batch request id
-	 * @return the list of unique event ids associated with the requestId that were removed
+	 * @return the list of unique events associated with the requestId that were removed, or null
+	 * if no events are associated with the {@code requestId}
 	 */
-	List<String> removeWaitingEvents(final String requestId) {
+	List<Event> removeWaitingEvents(final String requestId) {
 		if (StringUtils.isNullOrEmpty(requestId)) {
 			return null;
 		}
 
 		synchronized (mutex) {
-			final List<WaitingEventContext> temp = sentEventsWaitingResponse.remove(requestId);
-
-			if (temp == null) {
-				return null;
-			}
-
-			final List<String> eventIds = new ArrayList<>();
-
-			for (WaitingEventContext context : temp) {
-				eventIds.add(context.getUuid());
-			}
-
-			return eventIds;
+			return sentEventsWaitingResponse.remove(requestId);
 		}
 	}
 
@@ -152,7 +136,7 @@ class NetworkResponseHandler {
 		}
 
 		synchronized (mutex) {
-			final List<WaitingEventContext> temp = sentEventsWaitingResponse.get(requestId);
+			final List<Event> temp = sentEventsWaitingResponse.get(requestId);
 
 			if (temp == null) {
 				return Collections.emptyList();
@@ -160,8 +144,8 @@ class NetworkResponseHandler {
 
 			final List<String> eventIds = new ArrayList<>();
 
-			for (WaitingEventContext context : temp) {
-				eventIds.add(context.getUuid());
+			for (Event event : temp) {
+				eventIds.add(event.getUniqueIdentifier());
 			}
 
 			if (!temp.isEmpty()) {
@@ -291,6 +275,57 @@ class NetworkResponseHandler {
 				e.getLocalizedMessage()
 			);
 		}
+	}
+
+	/**
+	 * Process the on complete response from the network layer by unregistering request callbacks for
+	 * each event and dispatching completion events for the paired events which requested one.
+	 *
+	 * @param requestId the request id used to identify the request events
+	 */
+	void processResponseOnComplete(final String requestId) {
+		List<Event> removedWaitingEvents = removeWaitingEvents(requestId);
+
+		// unregister currently known completion callbacks
+		if (removedWaitingEvents != null) {
+			for (Event event : removedWaitingEvents) {
+				CompletionCallbacksManager.getInstance().unregisterCallback(event.getUniqueIdentifier());
+
+				if (sendCompletionRequested(event)) {
+					// send completion event
+					Map<String, Object> eventData = new HashMap<>();
+					addEventAndRequestIdToData(eventData, requestId, null);
+
+					Event responseEvent = new Event.Builder(
+						EdgeConstants.EventName.RESPONSE_COMPLETE,
+						EventType.EDGE,
+						"com.adobe.eventSource.contentComplete" // TODO replace with EventSource constant
+					)
+						.setEventData(eventData)
+						.inResponseToEvent(event)
+						.build();
+
+					MobileCore.dispatchEvent(responseEvent);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Extracts the boolean value of {@code request.sendCompletion} to determine if the given
+	 * {@code event} has requested a completion event.
+	 * @param event the {@code Event} to determine if a completion event is requested
+	 * @return true if a completion event is requested for the {@code event}, false if no completion event is requested.
+	 */
+	private boolean sendCompletionRequested(final Event event) {
+		Map<String, Object> eventData = event.getEventData();
+		Map<String, Object> requestProperties = DataReader.optTypedMap(
+			Object.class,
+			eventData,
+			EdgeConstants.EventDataKeys.Request.KEY,
+			null
+		);
+		return DataReader.optBoolean(requestProperties, EdgeConstants.EventDataKeys.Request.SEND_COMPLETION, false);
 	}
 
 	/**
@@ -635,14 +670,14 @@ class NetworkResponseHandler {
 		}
 
 		synchronized (mutex) {
-			final List<WaitingEventContext> contexts = sentEventsWaitingResponse.get(requestId);
+			final List<Event> contexts = sentEventsWaitingResponse.get(requestId);
 
 			if (contexts == null || contexts.isEmpty()) {
 				return false;
 			}
 
-			final WaitingEventContext firstContext = contexts.get(0);
-			return firstContext.getTimestamp() < lastResetDate;
+			final Event firstEvent = contexts.get(0);
+			return firstEvent.getTimestamp() < lastResetDate;
 		}
 	}
 
@@ -656,39 +691,5 @@ class NetworkResponseHandler {
 		}
 
 		return namedCollection.getLong(EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, 0);
-	}
-
-	/**
-	 * Stores a subset of {@link Event} information
-	 * required for matching the request events with the response payloads. See the usages of {@code sentEventsWaitingResponse}
-	 */
-	private class WaitingEventContext {
-
-		private final String uuid;
-		private final long timestamp;
-
-		/**
-		 * Creates a new context with the {@link Event} id and timestamp
-		 * @param uuid unique identifier of the {@code Event}
-		 * @param timestamp timestamp of the {@code Event} represented as milliseconds since 1970
-		 */
-		private WaitingEventContext(final String uuid, final long timestamp) {
-			this.uuid = uuid;
-			this.timestamp = timestamp;
-		}
-
-		/**
-		 * @return current unique identifier for this context
-		 */
-		String getUuid() {
-			return uuid;
-		}
-
-		/**
-		 * @return current timestamp for this context represented as milliseconds since 1970
-		 */
-		long getTimestamp() {
-			return timestamp;
-		}
 	}
 }

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
@@ -60,10 +60,10 @@ public class NetworkResponseHandlerTest {
 	private static final String EVENT_SOURCE_EXTENSION_RESPONSE_CONTENT = "com.adobe.eventSource.responseContent";
 	private static final String EVENT_SOURCE_EXTENSION_ERROR_RESPONSE_CONTENT =
 		"com.adobe.eventSource.errorResponseContent";
-	private static final String EVENT_SOURCE_RESPONSE_COMPLETE = "com.adobe.eventSource.contentComplete";
+	private static final String EVENT_SOURCE_CONTENT_COMPLETE = "com.adobe.eventSource.contentComplete";
 	private static final String EVENT_NAME_RESPONSE = "AEP Response Event Handle";
 	private static final String EVENT_NAME_ERROR_RESPONSE = "AEP Error Response";
-	private static final String EVENT_NAME_RESPONSE_COMPLETE = "AEP Response Complete";
+	private static final String EVENT_NAME_CONTENT_COMPLETE = "AEP Response Complete";
 	private static final String REQUEST_ID = "requestId";
 	private static final String REQUEST_EVENT_ID = "requestEventId";
 	private NetworkResponseHandler networkResponseHandler;
@@ -2057,9 +2057,9 @@ public class NetworkResponseHandlerTest {
 		for (int i = 0; i < parentEventIds.length; i++) {
 			Event returnedEvent = returnedEvents.get(i);
 			assertNotNull(returnedEvent);
-			assertEquals(EVENT_NAME_RESPONSE_COMPLETE, returnedEvent.getName());
+			assertEquals(EVENT_NAME_CONTENT_COMPLETE, returnedEvent.getName());
 			assertEquals(EVENT_TYPE_EDGE, returnedEvent.getType());
-			assertEquals(EVENT_SOURCE_RESPONSE_COMPLETE, returnedEvent.getSource());
+			assertEquals(EVENT_SOURCE_CONTENT_COMPLETE, returnedEvent.getSource());
 			assertEquals(expectedEventDatas[i], returnedEvent.getEventData());
 			assertEquals(parentEventIds[i], returnedEvent.getParentID());
 			assertEquals(parentEventIds[i], returnedEvent.getResponseID());

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
@@ -526,8 +526,16 @@ public class NetworkResponseHandlerTest {
 	}
 
 	@Test
-	public void testProcessResponseOnSuccess_WhenEmptyJsonResponse_doesNotDispatchEvent() {
+	public void testProcessResponseOnSuccess_WhenEmptyStringResponse_doesNotDispatchEvent() {
 		final String jsonResponse = "";
+		networkResponseHandler.processResponseOnSuccess(jsonResponse, "123");
+
+		mockCore.verify(() -> MobileCore.dispatchEvent(any(Event.class)), never());
+	}
+
+	@Test
+	public void testProcessResponseOnSuccess_WhenEmptyJsonResponse_doesNotDispatchEvent() {
+		final String jsonResponse = "{}";
 		networkResponseHandler.processResponseOnSuccess(jsonResponse, "123");
 
 		mockCore.verify(() -> MobileCore.dispatchEvent(any(Event.class)), never());

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
@@ -60,8 +60,10 @@ public class NetworkResponseHandlerTest {
 	private static final String EVENT_SOURCE_EXTENSION_RESPONSE_CONTENT = "com.adobe.eventSource.responseContent";
 	private static final String EVENT_SOURCE_EXTENSION_ERROR_RESPONSE_CONTENT =
 		"com.adobe.eventSource.errorResponseContent";
+	private static final String EVENT_SOURCE_RESPONSE_COMPLETE = "com.adobe.eventSource.contentComplete";
 	private static final String EVENT_NAME_RESPONSE = "AEP Response Event Handle";
 	private static final String EVENT_NAME_ERROR_RESPONSE = "AEP Error Response";
+	private static final String EVENT_NAME_RESPONSE_COMPLETE = "AEP Response Complete";
 	private static final String REQUEST_ID = "requestId";
 	private static final String REQUEST_EVENT_ID = "requestEventId";
 	private NetworkResponseHandler networkResponseHandler;
@@ -83,6 +85,48 @@ public class NetworkResponseHandlerTest {
 		public void setLocationHint(String hint, int ttlSeconds) {
 			receivedSetLocationHint = hint;
 			receivedSetTtlSeconds = ttlSeconds;
+		}
+	};
+
+	private static final Map<String, Object> requestSendCompletionTrueEventData = new HashMap<String, Object>() {
+		{
+			put(
+				"xdm",
+				new HashMap<String, Object>() {
+					{
+						put("test", "data");
+					}
+				}
+			);
+			put(
+				"request",
+				new HashMap<String, Object>() {
+					{
+						put("sendCompletion", true);
+					}
+				}
+			);
+		}
+	};
+
+	private static final Map<String, Object> requestSendCompletionFalseEventData = new HashMap<String, Object>() {
+		{
+			put(
+				"xdm",
+				new HashMap<String, Object>() {
+					{
+						put("test", "data");
+					}
+				}
+			);
+			put(
+				"request",
+				new HashMap<String, Object>() {
+					{
+						put("sendCompletion", false);
+					}
+				}
+			);
 		}
 	};
 
@@ -1601,6 +1645,131 @@ public class NetworkResponseHandlerTest {
 	}
 
 	@Test
+	public void testProcessResponseOnComplete_ifCompletionEventNotRequested_doesNotDispatchEvent() {
+		final String requestId = "123";
+		final Event requestEvent1 = new Event.Builder("test1", "testType", "testSource").build();
+		final Event requestEvent2 = new Event.Builder("test2", "testType", "testSource").build();
+
+		// test
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(requestEvent1);
+					add(requestEvent2);
+				}
+			}
+		);
+
+		networkResponseHandler.processResponseOnComplete(requestId);
+		mockCore.verify(() -> MobileCore.dispatchEvent(any(Event.class)), never());
+	}
+
+	@Test
+	public void testProcessResponseOnComplete_ifCompletionEventRequested_dispatchesEvent() {
+		final String requestId = "123";
+		final Event requestEvent1 = new Event.Builder("test1", "testType", "testSource")
+			.setEventData(requestSendCompletionTrueEventData)
+			.build();
+		final Event requestEvent2 = new Event.Builder("test2", "testType", "testSource").build();
+
+		// test
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(requestEvent1);
+					add(requestEvent2);
+				}
+			}
+		);
+
+		networkResponseHandler.processResponseOnComplete(requestId);
+
+		final Map<String, Object> expectedEventData = new HashMap<String, Object>() {
+			{
+				put("requestId", requestId);
+			}
+		};
+
+		assertResponseCompleteEventWithData(
+			new Map[] { expectedEventData },
+			new String[] { requestEvent1.getUniqueIdentifier() }
+		);
+	}
+
+	@Test
+	public void testProcessResponseOnComplete_ifMultipleCompletionEventRequested_dispatchesMultipleEvents() {
+		final String requestId = "123";
+		final Event requestEvent1 = new Event.Builder("test1", "testType", "testSource")
+			.setEventData(requestSendCompletionTrueEventData)
+			.build();
+		final Event requestEvent2 = new Event.Builder("test2", "testType", "testSource")
+			.setEventData(requestSendCompletionTrueEventData)
+			.build();
+
+		// test
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(requestEvent1);
+					add(requestEvent2);
+				}
+			}
+		);
+
+		networkResponseHandler.processResponseOnComplete(requestId);
+
+		final Map<String, Object> expectedEventData = new HashMap<String, Object>() {
+			{
+				put("requestId", requestId);
+			}
+		};
+
+		assertResponseCompleteEventWithData(
+			new Map[] { expectedEventData, expectedEventData },
+			new String[] { requestEvent1.getUniqueIdentifier(), requestEvent2.getUniqueIdentifier() }
+		);
+	}
+
+	@Test
+	public void testProcessResponseOnComplete_ifCompletionEventRequestFalse_doesNotDispatchEvent() {
+		final String requestId = "123";
+		final Event requestEvent1 = new Event.Builder("test1", "testType", "testSource")
+			.setEventData(requestSendCompletionFalseEventData)
+			.build();
+		final Event requestEvent2 = new Event.Builder("test2", "testType", "testSource")
+			.setEventData(requestSendCompletionTrueEventData)
+			.build();
+
+		// test
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(requestEvent1);
+					add(requestEvent2);
+				}
+			}
+		);
+
+		networkResponseHandler.processResponseOnComplete(requestId);
+
+		final Map<String, Object> expectedEventData = new HashMap<String, Object>() {
+			{
+				put("requestId", requestId);
+			}
+		};
+
+		// Assert complete event only dispatched for requestEvent2
+		assertResponseCompleteEventWithData(
+			new Map[] { expectedEventData },
+			new String[] { requestEvent2.getUniqueIdentifier() }
+		);
+	}
+
+	@Test
 	public void testAddWaitingEvents_addsNewList_happy() {
 		final String requestId = "test";
 		List<Event> eventsList = new ArrayList<>();
@@ -1874,5 +2043,26 @@ public class NetworkResponseHandlerTest {
 			: eventSource;
 		assertEquals(expectedEventSource, returnedEvent.getSource());
 		assertEquals(expectedEventData, returnedEvent.getEventData());
+	}
+
+	private void assertResponseCompleteEventWithData(
+		final Map<String, Object>[] expectedEventDatas,
+		final String[] parentEventIds
+	) {
+		ArgumentCaptor<Event> eventArgCaptor = ArgumentCaptor.forClass(Event.class);
+		mockCore.verify(() -> MobileCore.dispatchEvent(eventArgCaptor.capture()), times(parentEventIds.length));
+
+		List<Event> returnedEvents = eventArgCaptor.getAllValues();
+		assertEquals(parentEventIds.length, returnedEvents.size());
+		for (int i = 0; i < parentEventIds.length; i++) {
+			Event returnedEvent = returnedEvents.get(i);
+			assertNotNull(returnedEvent);
+			assertEquals(EVENT_NAME_RESPONSE_COMPLETE, returnedEvent.getName());
+			assertEquals(EVENT_TYPE_EDGE, returnedEvent.getType());
+			assertEquals(EVENT_SOURCE_RESPONSE_COMPLETE, returnedEvent.getSource());
+			assertEquals(expectedEventDatas[i], returnedEvent.getEventData());
+			assertEquals(parentEventIds[i], returnedEvent.getParentID());
+			assertEquals(parentEventIds[i], returnedEvent.getResponseID());
+		}
 	}
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Dispatch a "complete" event when the streaming connection is closed, when requested. This event may be used by extensions who are not using the public API `sendEvent` but wish to know when all response handles are received for a given request event.

Allows callers to add a flag to the Edge request to signal a "complete" event should be dispatched when the streaming connection is closed. The flag `sendCompletion` is part of the `request` object, a sibling object to the `data` and `xdm` objects in the Edge Experience Event.
```
{
   "xdm": { ... },
   "request": { "sendCompletion" : true }
}
```

The presence of the `sendCompletion` flag in the request causes the Edge extension to dispatch a *paired* response event to signal to the caller that the connection is closed and no more streaming response handles will be dispatched. The response event is of type `com.adobe.eventType.edge` and source `com.adobe.eventSource.contentComplete` and contains data of just `requestId` for debugging. The `parentId` of the event will match the UUID of the original request event.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
