### PR TITLE
Replace hardcoded event source with EventSource.CONTENT_COMPLETE

### DIFF
--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
@@ -308,7 +308,7 @@ public class EdgeFunctionalTests {
 				public void call(Event event) {
 					assertEquals("AEP Response Complete", event.getName());
 					assertEquals(EventType.EDGE, event.getType());
-					assertEquals("com.adobe.eventSource.contentComplete", event.getSource()); // TODO use EventSource
+					assertEquals(EventSource.CONTENT_COMPLETE, event.getSource());
 					assertEquals(edgeEvent.getUniqueIdentifier(), event.getParentID());
 					assertEquals(edgeEvent.getUniqueIdentifier(), event.getResponseID());
 					assertNotNull(event.getEventData());

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
@@ -1199,7 +1199,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			}
 		);
 		networkResponseHandler.processResponseOnComplete("123");
-		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, "com.adobe.eventSource.contentComplete");
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.CONTENT_COMPLETE);
 		assertEquals(0, dispatchEvents.size());
 	}
 
@@ -1215,7 +1215,7 @@ public class NetworkResponseHandlerFunctionalTests {
 			}
 		);
 		networkResponseHandler.processResponseOnComplete("123");
-		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, "com.adobe.eventSource.contentComplete");
+		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.CONTENT_COMPLETE);
 		assertEquals(1, dispatchEvents.size());
 
 		Map<String, String> flattenReceivedData = FunctionalTestUtils.flattenMap(dispatchEvents.get(0).getEventData());

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
@@ -299,7 +299,7 @@ class NetworkResponseHandler {
 					Event responseEvent = new Event.Builder(
 						EdgeConstants.EventName.CONTENT_COMPLETE,
 						EventType.EDGE,
-						"com.adobe.eventSource.contentComplete" // TODO replace with EventSource constant
+						EventSource.CONTENT_COMPLETE
 					)
 						.setEventData(eventData)
 						.inResponseToEvent(event)

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/UtilsTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/UtilsTests.java
@@ -143,7 +143,7 @@ public class UtilsTests {
 	}
 
 	@Test
-	public void testDeepCopy_whenInvalidMapWithCustomObjects_returnsNullAndNoThrow() {
+	public void testDeepCopy_whenInvalidMapWithCustomObjects_returnsOnlyValidObjects() {
 		class CustomObj {
 
 			private final int value;
@@ -157,7 +157,10 @@ public class UtilsTests {
 		map.put("key2", new CustomObj(1000));
 
 		Map<String, Object> deepCopy = Utils.deepCopy(map);
-		assertNull(deepCopy);
+
+		Map<String, Object> expected = new HashMap<>();
+		expected.put("key1", "value1");
+		assertEquals(expected, deepCopy);
 	}
 
 	@Test

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -28,7 +28,7 @@ mavenRepoDescription=Adobe Experience Platform Edge extension for the Adobe Expe
 mavenUploadDryRunFlag=false
 
 # production versions for production build
-mavenCoreVersion=2.2.0
+mavenCoreVersion=2.4.0
 mavenIdentityVersion=2.0.0
 androidxAnnotationVersion=1.0.0
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Update Core dependency to 2.4.0
- Replace hardcoded "com.adobe.eventSource.contentComplete" with Core's EventSource.CONTENT_COMPLETE
- Fix failing Utils deep copy test after Core's fix to ignore invalid objects in maps

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
