### PR TITLE
Integration test workflow update

### DIFF
--- a/.github/workflows/upstream-integration-test.yml
+++ b/.github/workflows/upstream-integration-test.yml
@@ -94,7 +94,7 @@ jobs:
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true
-        script: make ci-upstream-integration-test
+        script: make ci-upstream-integration-test EDGE_ENVIRONMENT=${{ github.event.inputs.environment }} EDGE_LOCATION_HINT=${{ github.event.inputs.edge-location-hint }}
     
     # Potential workflow solutions on job failure
     - name: On failure

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ci-functional-test: create-ci
 
 ci-upstream-integration-test:
 	(./code/gradlew -p code/upstream-integration-tests uninstallDebugAndroidTest)
-	(./code/gradlew -p code/upstream-integration-tests connectedDebugAndroidTest)
+	(./code/gradlew -p code/upstream-integration-tests connectedDebugAndroidTest -PEDGE_ENVIRONMENT=$(EDGE_ENVIRONMENT) -PEDGE_LOCATION_HINT=$(EDGE_LOCATION_HINT))
 
 ci-javadoc: create-ci
 	(mkdir -p ci/javadoc)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates the make rule for integration test to pass `EDGE_LOCATION_HINT` and `EDGE_ENVIRONMENT`, which are set in the BuildConfig available to the integration test class

In the CircleCI case which will trigger after merge to `staging` and `main`, the two variables should be unset, resulting in empty string values, which the test class should interpret as:
1. `EDGE_LOCATION_HINT` = none (that is, each test case has no prior location hint set)
2. `EDGE_ENVIRONMENT` = prod
That is, this configuration will be the path tested for production releases.

In the manual trigger workflow case via GitHub Actions, the values can be set to the desired values.

**Question for reviewers**:
Currently, the GitHub Action workflow only allows Edge location hint to be set to none (empty string) or the known list of valid location hints currently recognized/allowed by Edge, using a dropdown list of predetermined options. Should this be changed to freeform text to allow testers to test the following use cases?: 
1. Invalid location hints
2. An updated or new location hint recognized/allowed by Edge Network

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
