### PR TITLE
Log generic network failure when HTTP code is -1. Log retry interval.

### DIFF
--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeNetworkService.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeNetworkService.java
@@ -200,7 +200,7 @@ class EdgeNetworkService {
 				Log.debug(
 					LOG_TAG,
 					LOG_SOURCE,
-					"Connection to Experience Edge returned recoverable error code. Connection failure. Will retry request in %d seconds.",
+					"Connection to Experience Edge failed. Failed to read message/error code from NetworkService. Will retry request in %d seconds.",
 					retryResult.getRetryIntervalSeconds()
 				);
 			} else {

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
@@ -331,12 +331,40 @@ public class EdgeNetworkServiceTest {
 	}
 
 	@Test
-	public void testDoRequest_whenConnection_RecoverableResponseCode_ReturnsRetryYes_AndNoResponseCallback_AndNoErrorCallback() {
+	public void testDoRequest_whenConnection_RecoverableResponseCode_negative1_ReturnsRetryYes_AndNoResponseCallback_AndNoErrorCallback() {
+		testRecoverableNetworkResponse(-1, null);
+	}
+
+	@Test
+	public void testDoRequest_whenConnection_RecoverableResponseCode_408_ReturnsRetryYes_AndNoResponseCallback_AndNoErrorCallback() {
+		testRecoverableNetworkResponse(408, "Request Timeout");
+	}
+
+	@Test
+	public void testDoRequest_whenConnection_RecoverableResponseCode_429_ReturnsRetryYes_AndNoResponseCallback_AndNoErrorCallback() {
+		testRecoverableNetworkResponse(429, "Too Many Requests");
+	}
+
+	@Test
+	public void testDoRequest_whenConnection_RecoverableResponseCode_502_ReturnsRetryYes_AndNoResponseCallback_AndNoErrorCallback() {
+		testRecoverableNetworkResponse(502, "Bad Gateway");
+	}
+
+	@Test
+	public void testDoRequest_whenConnection_RecoverableResponseCode_503_ReturnsRetryYes_AndNoResponseCallback_AndNoErrorCallback() {
+		testRecoverableNetworkResponse(503, "Service Unavailable");
+	}
+
+	@Test
+	public void testDoRequest_whenConnection_RecoverableResponseCode_504_ReturnsRetryYes_AndNoResponseCallback_AndNoErrorCallback() {
+		testRecoverableNetworkResponse(504, "Gateway Timeout");
+	}
+
+	private void testRecoverableNetworkResponse(final int responseCode, final String errorString) {
 		// setup
 		final String url = "https://test.com";
 		final String jsonRequest = "{}";
-		final String errorStr = "Service Unavailable";
-		MockConnection mockConnection = new MockConnection(503, null, errorStr, null);
+		MockConnection mockConnection = new MockConnection(responseCode, null, errorString, null);
 		mockNetworkService.mockConnectAsyncConnection = mockConnection;
 		networkService = new EdgeNetworkService(mockNetworkService);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When a network connection fails before a connection is made to the server, the connection is given a response code of -1 and no message. This gets logged as "Connection to Experience Edge returned recoverable error code (-1). Response message: null." This may be confusing to users who'd expect "null" to be something. This fix replaces the log entry with a more generic error message, "Connection to Experience Edge failed. Failed to read message/error code from NetworkService."

Additionally, requests which will be retried are logged with a message stating the request will be retried at a specified interval: "... Will retry request in %d seconds."

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
