### PR TITLE
[breaking change] Remove deprecated date formatters.

### DIFF
--- a/code/edge/src/main/java/com/adobe/marketing/mobile/xdm/Formatters.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/xdm/Formatters.java
@@ -11,13 +11,9 @@
 
 package com.adobe.marketing.mobile.xdm;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.TimeZone;
 
 public final class Formatters {
 
@@ -42,54 +38,6 @@ public final class Formatters {
 		}
 
 		return serializedList;
-	}
-
-	// example: 2017-09-26T15:52:25-07:00
-	private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-	private static final String DATE_FORMAT = "yyyy-MM-dd";
-
-	/**
-	 * Formats a {@code Date} to an ISO 8601 date-time string in UTC as defined in
-	 * <a href="https://tools.ietf.org/html/rfc3339#section-5.6">RFC 3339, section 5.6</a>
-	 * For example, 2017-09-26T15:52:25Z
-	 *
-	 * @param timestamp a timestamp
-	 * @return {@code timestamp} formatted to a string in the format of 'yyyy-MM-dd'T'HH:mm:ss'Z'',
-	 * or an empty string if {@code timestamp} is null
-	 *
-	 * @deprecated as of 2.0.0, replaced by {@code TimeUtils.getISO8601UTCDateWithMilliseconds} from Mobile Core
-	 */
-	@Deprecated
-	public static String dateToISO8601String(final Date timestamp) {
-		if (timestamp == null) {
-			return "";
-		}
-
-		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(TIMESTAMP_FORMAT, Locale.US);
-		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-		return simpleDateFormat.format(timestamp);
-	}
-
-	/**
-	 * Formats a {@code Date} to a full-date string defined in
-	 * <a href="https://tools.ietf.org/html/rfc3339#section-5.6">RFC 3339, section 5.6</a>,
-	 * representing a date without time.
-	 * For example, 2017-09-26
-	 *
-	 * @param date a date
-	 * @return {@code date} formatted to a string in the format of 'yyy-MM-dd', or an empty string
-	 * if {@code date} is null
-	 *
-	 * @deprecated as of 2.0.0, replaced by {@code TimeUtils.getISO8601FullDate} from Mobile Core
-	 */
-	@Deprecated
-	public static String dateToShortDateString(final Date date) {
-		if (date == null) {
-			return "";
-		}
-
-		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DATE_FORMAT, Locale.US);
-		return simpleDateFormat.format(date);
 	}
 
 	private Formatters() {}

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/xdm/FormattersTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/xdm/FormattersTests.java
@@ -15,62 +15,12 @@ import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 import org.junit.Test;
 
 public class FormattersTests {
-
-	@Test
-	@SuppressWarnings("deprecation")
-	public void dateToISO8601String_onValidTimestamp_returnsFormattedString() {
-		Calendar cal = new Calendar.Builder()
-			.set(Calendar.YEAR, 2019)
-			.set(Calendar.MONTH, Calendar.SEPTEMBER)
-			.set(Calendar.DAY_OF_MONTH, 23)
-			.set(Calendar.HOUR, 11)
-			.set(Calendar.MINUTE, 15)
-			.set(Calendar.SECOND, 45)
-			.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"))
-			.build();
-
-		String serializedDate = Formatters.dateToISO8601String(cal.getTime());
-		// Expected time in UTC which is +7 hours from America/Los_Angeles during Daylight Savings
-		assertEquals("2019-09-23T18:15:45Z", serializedDate);
-	}
-
-	@Test
-	@SuppressWarnings("deprecation")
-	public void dateToISO8601String_onNull_returnsEmptyString() {
-		String serializedDate = Formatters.dateToISO8601String(null);
-		assertEquals("", serializedDate);
-	}
-
-	@Test
-	@SuppressWarnings("deprecation")
-	public void dateToShortDateString_onValidTimestamp_returnsFormattedString() {
-		Calendar cal = new Calendar.Builder()
-			.set(Calendar.YEAR, 2019)
-			.set(Calendar.MONTH, Calendar.SEPTEMBER)
-			.set(Calendar.DAY_OF_MONTH, 23)
-			.set(Calendar.HOUR, 11)
-			.set(Calendar.MINUTE, 15)
-			.set(Calendar.SECOND, 45)
-			.build();
-
-		String serializedDate = Formatters.dateToShortDateString(cal.getTime());
-		assertEquals("2019-09-23", serializedDate);
-	}
-
-	@Test
-	@SuppressWarnings("deprecation")
-	public void dateToShortDateString_onNull_returnsEmptyString() {
-		String serializedDate = Formatters.dateToShortDateString(null);
-		assertEquals("", serializedDate);
-	}
 
 	@Test
 	public void serializeFromList_singlePropertyList_returnsMapWithSingleProperty() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed deprecated function `Formatters.dateToISO8601String()`, replaced by `TimeUtils.getISO8601UTCDateWithMilliseconds()` in MobileCore.
Removed deprecated function `Formatters.dateToShortDateString()`, replaced by `TimeUtils.getISO8601FullDate()` in MobileCore.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
