### PR TITLE
[CI] Move parameters to pipeline level, add "build-path" parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,30 +15,31 @@ orbs:
   android: circleci/android@2.4.0
   codecov: codecov/codecov@4.0.1
 
+# Define pipeline parameters available to all jobs
+parameters:
+  gradle-cache-prefix:
+    type: string
+    default: v1
+  build-cache-prefix:
+    type: string
+    default: v1
+
 # Workflows orchestrate a set of jobs to be run;
 workflows:
   version: 2
   build-test-deploy:
     jobs:
-      - validate-code:
-          gradle-cache-prefix: v1
-          build-cache-prefix: v1
+      - validate-code
 
       - build-and-unit-test:
-          gradle-cache-prefix: v1
-          build-cache-prefix: v1
           requires:
             - validate-code
 
       - functional-test:
-          gradle-cache-prefix: v1
-          build-cache-prefix: v1
           requires:
             - validate-code
-      
+
       - integration-test:
-          gradle-cache-prefix: v1
-          build-cache-prefix: v1
           requires:
             - validate-code
           filters:
@@ -49,13 +50,6 @@ workflows:
 
 jobs:
   validate-code:
-    parameters:
-      gradle-cache-prefix:
-        type: string
-        default: v1
-      build-cache-prefix:
-        type: string
-        default: v1
 
     # List of available Android Docker images: https://circleci.com/developer/images/image/cimg/android#image-tags
     executor:
@@ -66,9 +60,9 @@ jobs:
       - checkout
 
       - android/restore-gradle-cache:
-          cache-prefix: << parameters.gradle-cache-prefix >>
+          cache-prefix: << pipeline.parameters.gradle-cache-prefix >>
       - android/restore-build-cache:
-          cache-prefix: << parameters.build-cache-prefix >>
+          cache-prefix: << pipeline.parameters.build-cache-prefix >>
 
       - run:
           name: Check Format
@@ -79,22 +73,15 @@ jobs:
           command: make lint
 
       - android/save-gradle-cache:
-          cache-prefix: << parameters.gradle-cache-prefix >>
+          cache-prefix: << pipeline.parameters.gradle-cache-prefix >>
       - android/save-build-cache:
-          cache-prefix: << parameters.build-cache-prefix >>
+          cache-prefix: << pipeline.parameters.build-cache-prefix >>
 
       # Store Lint report
       - store_artifacts:
           path: code/edge/build/reports
 
   build-and-unit-test:
-    parameters:
-      gradle-cache-prefix:
-        type: string
-        default: v1
-      build-cache-prefix:
-        type: string
-        default: v1
 
     # List of available Android Docker images: https://circleci.com/developer/images/image/cimg/android#image-tags
     executor:
@@ -105,9 +92,9 @@ jobs:
       - checkout
 
       - android/restore-gradle-cache:
-          cache-prefix: << parameters.gradle-cache-prefix >>
+          cache-prefix: << pipeline.parameters.gradle-cache-prefix >>
       - android/restore-build-cache:
-          cache-prefix: << parameters.build-cache-prefix >>
+          cache-prefix: << pipeline.parameters.build-cache-prefix >>
 
       - run:
           name: Javadoc
@@ -131,9 +118,9 @@ jobs:
           test-command: make unit-test-coverage
 
       - android/save-gradle-cache:
-          cache-prefix: << parameters.gradle-cache-prefix >>
+          cache-prefix: << pipeline.parameters.gradle-cache-prefix >>
       - android/save-build-cache:
-          cache-prefix: << parameters.build-cache-prefix >>
+          cache-prefix: << pipeline.parameters.build-cache-prefix >>
 
       - store_artifacts:
           path: code/edge/build/reports/tests
@@ -148,13 +135,6 @@ jobs:
           flags: unit-tests
 
   functional-test:
-    parameters:
-      gradle-cache-prefix:
-        type: string
-        default: v1
-      build-cache-prefix:
-        type: string
-        default: v1
 
     # list of available Android machine images: https://circleci.com/developer/machine/image/android#image-tags
     executor:
@@ -165,7 +145,7 @@ jobs:
       - checkout
 
       - android/restore-build-cache:
-          cache-prefix: << parameters.build-cache-prefix >>
+          cache-prefix: << pipeline.parameters.build-cache-prefix >>
 
       - run:
           name: List available emulator images
@@ -178,10 +158,10 @@ jobs:
           post-emulator-launch-assemble-command: make assemble-phone
           #   The test command
           test-command: make functional-test-coverage
-          restore-gradle-cache-prefix: << parameters.gradle-cache-prefix >>
+          restore-gradle-cache-prefix: << pipeline.parameters.gradle-cache-prefix >>
 
       - android/save-build-cache:
-          cache-prefix: << parameters.build-cache-prefix >>
+          cache-prefix: << pipeline.parameters.build-cache-prefix >>
 
       - store_artifacts:
           path: code/edge/build/reports/androidTests
@@ -196,13 +176,6 @@ jobs:
           flags: functional-tests
 
   integration-test:
-    parameters:
-      gradle-cache-prefix:
-        type: string
-        default: v1
-      build-cache-prefix:
-        type: string
-        default: v1
 
     # list of available Android machine images: https://circleci.com/developer/machine/image/android#image-tags
     executor:
@@ -213,7 +186,7 @@ jobs:
       - checkout
 
       - android/restore-build-cache:
-          cache-prefix: << parameters.build-cache-prefix >>
+          cache-prefix: << pipeline.parameters.build-cache-prefix >>
 
       - run:
           name: List available emulator images
@@ -226,10 +199,10 @@ jobs:
           post-emulator-launch-assemble-command: make assemble-phone
           #   The test command
           test-command: make upstream-integration-test
-          restore-gradle-cache-prefix: << parameters.gradle-cache-prefix >>
+          restore-gradle-cache-prefix: << pipeline.parameters.gradle-cache-prefix >>
 
       - android/save-build-cache:
-          cache-prefix: << parameters.build-cache-prefix >>
+          cache-prefix: << pipeline.parameters.build-cache-prefix >>
 
       # On test failures, the step in the Makefile to copy the reports to ci/ is not run, so store test results from build folder instead.
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ parameters:
   build-cache-prefix:
     type: string
     default: v1
+  build-path:
+    type: string
+    default: code/edge/build
 
 # Workflows orchestrate a set of jobs to be run;
 workflows:
@@ -79,7 +82,7 @@ jobs:
 
       # Store Lint report
       - store_artifacts:
-          path: code/edge/build/reports
+          path: << pipeline.parameters.build-path >>/reports
 
   build-and-unit-test:
 
@@ -100,7 +103,7 @@ jobs:
           name: Javadoc
           command: make javadoc
       - store_artifacts:
-          path: code/edge/build/dokka/javadoc
+          path: << pipeline.parameters.build-path >>/dokka/javadoc
 
       - run:
           name: Assemble Phone
@@ -123,15 +126,15 @@ jobs:
           cache-prefix: << pipeline.parameters.build-cache-prefix >>
 
       - store_artifacts:
-          path: code/edge/build/reports/tests
+          path: << pipeline.parameters.build-path >>/reports/tests
 
       - store_test_results:
-          path: code/edge/build/test-results/testPhoneDebugUnitTest
+          path: << pipeline.parameters.build-path >>/test-results/testPhoneDebugUnitTest
 
       # Code coverage upload using Codecov
       # See options explanation here: https://docs.codecov.com/docs/codecov-uploader
       - codecov/upload:
-          file: code/edge/build/reports/coverage/test/phone/debug/report.xml
+          file: << pipeline.parameters.build-path >>/reports/coverage/test/phone/debug/report.xml
           flags: unit-tests
 
   functional-test:
@@ -164,15 +167,15 @@ jobs:
           cache-prefix: << pipeline.parameters.build-cache-prefix >>
 
       - store_artifacts:
-          path: code/edge/build/reports/androidTests
+          path: << pipeline.parameters.build-path >>/reports/androidTests
 
       - store_test_results:
-          path: code/edge/build/outputs/androidTest-results
+          path: << pipeline.parameters.build-path >>/outputs/androidTest-results
 
       # Code coverage upload using Codecov
       # See options explanation here: https://docs.codecov.com/docs/codecov-uploader
       - codecov/upload:
-          file: code/edge/build/reports/coverage/androidTest/phone/debug/connected/report.xml
+          file: << pipeline.parameters.build-path >>/reports/coverage/androidTest/phone/debug/connected/report.xml
           flags: functional-tests
 
   integration-test:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates CircleCI configuration:

1. Moves parameters from Job level to Pipeline level. Pipeline parameters are available to all jobs. The change removes redundant code for common cache prefix variables.
2. Adds parameter "build-path" to extract out common build path to a single variable.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
