### PR TITLE
Adapt the NetworkService changes in Edge

### DIFF
--- a/code/app-kotlin/build.gradle.kts
+++ b/code/app-kotlin/build.gradle.kts
@@ -67,6 +67,10 @@ android {
     }
 }
 
+configurations.configureEach {
+    resolutionStrategy.cacheChangingModulesFor(0, "seconds")
+}
+
 dependencies {
     implementation(project(":edge"))
     implementation(project(":app-util-xdm"))

--- a/code/app/build.gradle.kts
+++ b/code/app/build.gradle.kts
@@ -64,6 +64,10 @@ android {
     }
 }
 
+configurations.configureEach {
+    resolutionStrategy.cacheChangingModulesFor(0, "seconds")
+}
+
 dependencies {
     implementation(project(":edge"))
     implementation(project(":app-util-xdm"))

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
@@ -209,6 +209,17 @@ class EdgeHitProcessor implements HitProcessing {
 		}
 	}
 
+	/**
+	 * Validates a given URL.
+	 * Checks that a URL is valid by ensuring:
+	 * <ul>
+	 *     <li>The URL is not null or empty.</li>
+	 *     <li>The URL is parsable by the {@link java.net.URL} class.</li>
+	 *     <li>The URL scheme is "HTTPS".</li>
+	 * </ul>
+	 * @param url the URL string to validate
+	 * @return true if the URL is valid, false otherwise.
+	 */
 	private boolean isValidUrl(final String url) {
 		if (!UrlUtils.isValidUrl(url)) {
 			Log.debug(LOG_TAG, LOG_SOURCE, "Request invalid, URL is malformed, '%s'.", url);

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
@@ -24,6 +24,7 @@ import com.adobe.marketing.mobile.services.NamedCollection;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.MapUtils;
 import com.adobe.marketing.mobile.util.StringUtils;
+import com.adobe.marketing.mobile.util.UrlUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -150,6 +151,28 @@ class EdgeHitProcessor implements HitProcessing {
 			edgeHit.getDatastreamId(),
 			edgeHit.getRequestId()
 		);
+
+		if (!UrlUtils.isValidUrl(url)) {
+			Log.warning(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Unable to send network request with id (%s) as url is malformed, '%s'.",
+				edgeHit.getRequestId(),
+				url
+			);
+			return true;
+		}
+
+		if (!url.startsWith("https")) {
+			Log.warning(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Unable to send network request with id (%s) as url scheme must be 'https', '%s'.",
+				edgeHit.getRequestId(),
+				url
+			);
+			return true;
+		}
 
 		try {
 			Log.debug(

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
@@ -152,25 +152,15 @@ class EdgeHitProcessor implements HitProcessing {
 			edgeHit.getRequestId()
 		);
 
-		if (!UrlUtils.isValidUrl(url)) {
+		if (!isValidUrl(url)) {
 			Log.warning(
 				LOG_TAG,
 				LOG_SOURCE,
-				"Unable to send network request with id (%s) as url is malformed, '%s'.",
-				edgeHit.getRequestId(),
+				"Unable to send network request for entity (%s) as URL is malformed or scheme is not 'https', '%s'.",
+				entityId,
 				url
 			);
-			return true;
-		}
 
-		if (!url.startsWith("https")) {
-			Log.warning(
-				LOG_TAG,
-				LOG_SOURCE,
-				"Unable to send network request with id (%s) as url scheme must be 'https', '%s'.",
-				edgeHit.getRequestId(),
-				url
-			);
 			return true;
 		}
 
@@ -217,6 +207,20 @@ class EdgeHitProcessor implements HitProcessing {
 
 			return false; // Hit failed to send, retry after interval
 		}
+	}
+
+	private boolean isValidUrl(final String url) {
+		if (!UrlUtils.isValidUrl(url)) {
+			Log.debug(LOG_TAG, LOG_SOURCE, "Request invalid, URL is malformed, '%s'.", url);
+			return false;
+		}
+
+		if (!url.startsWith("https")) {
+			Log.debug(LOG_TAG, LOG_SOURCE, "Request invalid, URL scheme must be 'https', '%s'.", url);
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorTests.java
@@ -573,8 +573,7 @@ public class EdgeHitProcessorTests {
 	}
 
 	@Test
-	public void testSendNetworkRequest_returnsTrue_doesNotSendNetworkRequest_whenMalformedUrl()
-		throws InterruptedException {
+	public void testSendNetworkRequest_whenMalformedUrl_returnsTrue_doesNotSendNetworkRequest() {
 		// setup
 		final String configId = "456";
 		final JSONObject requestBody = getOneEventJson();
@@ -604,8 +603,7 @@ public class EdgeHitProcessorTests {
 	}
 
 	@Test
-	public void testSendNetworkRequest_returnsTrue_doesNotSendNetworkRequest_whenWrongScheme()
-		throws InterruptedException {
+	public void testSendNetworkRequest_whenWrongScheme_returnsTrue_doesNotSendNetworkRequest() {
 		// setup
 		final String configId = "456";
 		final JSONObject requestBody = getOneEventJson();

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorTests.java
@@ -589,7 +589,7 @@ public class EdgeHitProcessorTests {
 		when(mockEdgeNetworkService.buildUrl(endpoint, configId, hit.getRequestId()))
 			.thenReturn("https://www.adobe.com:_80/");
 
-		hitProcessor.sendNetworkRequest(null, hit, new HashMap<String, String>());
+		final boolean hitComplete = hitProcessor.sendNetworkRequest(null, hit, new HashMap<String, String>());
 
 		// verify
 		verify(mockEdgeNetworkService, never())
@@ -599,6 +599,8 @@ public class EdgeHitProcessorTests {
 				ArgumentMatchers.anyMap(),
 				any(EdgeNetworkService.ResponseCallback.class)
 			);
+
+		assertTrue(hitComplete);
 	}
 
 	@Test
@@ -617,7 +619,7 @@ public class EdgeHitProcessorTests {
 		final EdgeHit hit = new EdgeHit(configId, requestBody, endpoint);
 		when(mockEdgeNetworkService.buildUrl(endpoint, configId, hit.getRequestId())).thenReturn("http://test.com");
 
-		hitProcessor.sendNetworkRequest(null, hit, new HashMap<String, String>());
+		final boolean hitComplete = hitProcessor.sendNetworkRequest(null, hit, new HashMap<String, String>());
 
 		// verify
 		verify(mockEdgeNetworkService, never())
@@ -627,6 +629,8 @@ public class EdgeHitProcessorTests {
 				ArgumentMatchers.anyMap(),
 				any(EdgeNetworkService.ResponseCallback.class)
 			);
+
+		assertTrue(hitComplete);
 	}
 
 	@Test

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorTests.java
@@ -573,6 +573,63 @@ public class EdgeHitProcessorTests {
 	}
 
 	@Test
+	public void testSendNetworkRequest_returnsTrue_doesNotSendNetworkRequest_whenMalformedUrl()
+		throws InterruptedException {
+		// setup
+		final String configId = "456";
+		final JSONObject requestBody = getOneEventJson();
+		final EdgeEndpoint endpoint = new EdgeEndpoint(
+			EdgeNetworkService.RequestType.INTERACT,
+			"prod",
+			null,
+			null,
+			null
+		);
+		final EdgeHit hit = new EdgeHit(configId, requestBody, endpoint);
+		when(mockEdgeNetworkService.buildUrl(endpoint, configId, hit.getRequestId()))
+			.thenReturn("https://www.adobe.com:_80/");
+
+		hitProcessor.sendNetworkRequest(null, hit, new HashMap<String, String>());
+
+		// verify
+		verify(mockEdgeNetworkService, never())
+			.doRequest(
+				anyString(),
+				anyString(),
+				ArgumentMatchers.anyMap(),
+				any(EdgeNetworkService.ResponseCallback.class)
+			);
+	}
+
+	@Test
+	public void testSendNetworkRequest_returnsTrue_doesNotSendNetworkRequest_whenWrongScheme()
+		throws InterruptedException {
+		// setup
+		final String configId = "456";
+		final JSONObject requestBody = getOneEventJson();
+		final EdgeEndpoint endpoint = new EdgeEndpoint(
+			EdgeNetworkService.RequestType.INTERACT,
+			"prod",
+			null,
+			null,
+			null
+		);
+		final EdgeHit hit = new EdgeHit(configId, requestBody, endpoint);
+		when(mockEdgeNetworkService.buildUrl(endpoint, configId, hit.getRequestId())).thenReturn("http://test.com");
+
+		hitProcessor.sendNetworkRequest(null, hit, new HashMap<String, String>());
+
+		// verify
+		verify(mockEdgeNetworkService, never())
+			.doRequest(
+				anyString(),
+				anyString(),
+				ArgumentMatchers.anyMap(),
+				any(EdgeNetworkService.ResponseCallback.class)
+			);
+	}
+
+	@Test
 	public void testProcessHit_onResetHit_clearsStatePayloads() throws InterruptedException {
 		// setup
 		final Event resetEvent = new Event.Builder("Reset Event", EventType.EDGE_IDENTITY, EventSource.RESET_COMPLETE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adapts Edge extension with the latest NetworkService changes (https://github.com/adobe/aepsdk-core-android/pull/612)
The latest NetworkService changed the meaning of "null" values returned from `connectAsync`. 

1. `NetworkService.connectAsync` now returns null if no network connection is detected. In this case, Edge Extension must keep the event in the queue to process later, once the network connection is established.
2. As previously, `NetworkService.connectAsync` will return null if the given URL is malformed or uses a scheme other than `https`.  It is now required for extensions to validate the URL before passing to `connectAsync`.

For 1 above, the Edge Extension already handled null network connection by retrying the request, so no changes are required. Unit tests already validate this case, https://github.com/adobe/aepsdk-edge-android/blob/dev-v3.0.0/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java#L162

For 2, this PR adds checks for malformed URL or incorrect URL scheme to `EdgeHitProcessor`. 


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit tests added to validate malformed URLs and URLs with incorrect scheme cause the request to be dropped.

Performed manual testing to verify events are queued and retried when the device has no Internet connection. Tested both on real device and simulator.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
