### PR TITLE
Update dependencies to use non-snapshot 3.0.0 versions

### DIFF
--- a/code/app-kotlin/build.gradle.kts
+++ b/code/app-kotlin/build.gradle.kts
@@ -75,17 +75,12 @@ dependencies {
     implementation(project(":edge"))
     implementation(project(":app-util-xdm"))
 
-    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion-SNAPSHOT")
-    implementation("com.adobe.marketing.mobile:edgeidentity:$mavenEdgeIdentityVersion-SNAPSHOT") {
-        exclude(group = "com.adobe.marketing.mobile", module = "core")
-    }
+    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion")
+    implementation("com.adobe.marketing.mobile:edgeidentity:$mavenEdgeIdentityVersion")
     implementation("com.adobe.marketing.mobile:edgeconsent:3.0.0-SNAPSHOT") {
         exclude(group = "com.adobe.marketing.mobile", module = "edge")
-        exclude(group = "com.adobe.marketing.mobile", module = "core")
     }
-    implementation("com.adobe.marketing.mobile:assurance:3.0.0-SNAPSHOT") {
-        exclude(group = "com.adobe.marketing.mobile", module = "core")
-    }
+    implementation("com.adobe.marketing.mobile:assurance:3.0.0")
 
     implementation("androidx.constraintlayout:constraintlayout:2.0.4")
 

--- a/code/app-util-xdm/build.gradle.kts
+++ b/code/app-util-xdm/build.gradle.kts
@@ -49,5 +49,5 @@ android {
 
 dependencies {
     implementation(project(":edge"))
-    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion-SNAPSHOT")
+    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion")
 }

--- a/code/app/build.gradle.kts
+++ b/code/app/build.gradle.kts
@@ -72,17 +72,12 @@ dependencies {
     implementation(project(":edge"))
     implementation(project(":app-util-xdm"))
 
-    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion-SNAPSHOT")
-    implementation("com.adobe.marketing.mobile:edgeidentity:$mavenEdgeIdentityVersion-SNAPSHOT") {
-        exclude(group = "com.adobe.marketing.mobile", module = "core")
-    }
+    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion")
+    implementation("com.adobe.marketing.mobile:edgeidentity:$mavenEdgeIdentityVersion")
     implementation("com.adobe.marketing.mobile:edgeconsent:3.0.0-SNAPSHOT") {
         exclude(group = "com.adobe.marketing.mobile", module = "edge")
-        exclude(group = "com.adobe.marketing.mobile", module = "core")
     }
-    implementation("com.adobe.marketing.mobile:assurance:3.0.0-SNAPSHOT") {
-        exclude(group = "com.adobe.marketing.mobile", module = "core")
-    }
+    implementation("com.adobe.marketing.mobile:assurance:3.0.0")
 
     implementation("androidx.constraintlayout:constraintlayout:2.0.4")
 

--- a/code/edge/build.gradle.kts
+++ b/code/edge/build.gradle.kts
@@ -31,11 +31,8 @@ aepLibrary {
 }
 
 dependencies {
-    // Stop using SNAPSHOT after Core release.
-    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion-SNAPSHOT")
-    implementation("com.adobe.marketing.mobile:edgeidentity:$mavenEdgeIdentityVersion-SNAPSHOT") {
-        exclude(group = "com.adobe.marketing.mobile", module = "core")
-    }
+    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion")
+    implementation("com.adobe.marketing.mobile:edgeidentity:$mavenEdgeIdentityVersion")
 
     testImplementation(project(":test-utils"))
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.12.7")
@@ -43,7 +40,6 @@ dependencies {
     androidTestImplementation(project(":test-utils"))
     androidTestImplementation("com.adobe.marketing.mobile:edgeconsent:3.0.0-SNAPSHOT")
     {
-        exclude(group = "com.adobe.marketing.mobile", module = "core")
         exclude(group = "com.adobe.marketing.mobile", module = "edge")
     }
 }

--- a/code/test-utils/build.gradle.kts
+++ b/code/test-utils/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 
 dependencies {
     implementation(project(":edge"))
-    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion-SNAPSHOT")
+    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion")
 
     implementation("androidx.test.ext:junit:${BuildConstants.Versions.ANDROIDX_TEST_EXT_JUNIT}")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.12.7")

--- a/code/upstream-integration-tests/build.gradle.kts
+++ b/code/upstream-integration-tests/build.gradle.kts
@@ -18,6 +18,9 @@ plugins {
     id("com.diffplug.spotless")
 }
 
+val mavenCoreVersion: String by project
+val mavenEdgeIdentityVersion: String by project
+
 configure<com.diffplug.gradle.spotless.SpotlessExtension> {
     kotlin {
         target("src/*/java/**/*.kt")
@@ -86,10 +89,8 @@ dependencies {
 
     implementation("androidx.core:core-ktx:1.9.0")
 
-    androidTestImplementation("com.adobe.marketing.mobile:core:3.0.0-SNAPSHOT")
-    androidTestImplementation("com.adobe.marketing.mobile:edgeidentity:3.0.0-SNAPSHOT"){
-        exclude(group = "com.adobe.marketing.mobile", module = "core")
-    }
+    androidTestImplementation("com.adobe.marketing.mobile:core:$mavenCoreVersion")
+    androidTestImplementation("com.adobe.marketing.mobile:edgeidentity:$mavenEdgeIdentityVersion")
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
     androidTestImplementation("androidx.test:runner:1.4.0")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updating dependencies to non-snapshot versions of 3.0.0.

- Sets Core and Edge Identity dependencies in edgeidentity module to non-snapshot versions
- Updates app module to use non-snapshot version of Core, Edge Identity, and Assurance. However, as Edge is released before Consent, version 3.0.0-SNAPSHOT is still used.

Note, as Core 3.0.0 is not yet released, the CI build will fail.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
