### PR TITLE
Update After tear down to call resetTestExpections()

### DIFF
--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/CompletionHandlerFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/CompletionHandlerFunctionalTests.java
@@ -84,7 +84,7 @@ public class CompletionHandlerFunctionalTests {
 
 	@After
 	public void tearDown() {
-		mockNetworkService.reset();
+		resetTestExpectations();
 	}
 
 	@Test

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/ConfigOverridesFunctionalTests.kt
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/ConfigOverridesFunctionalTests.kt
@@ -49,8 +49,6 @@ class ConfigOverridesFunctionalTests {
     @Before
     @Throws(Exception::class)
     fun setup() {
-        resetTestExpectations()
-
         ServiceProvider.getInstance().networkService =
             mockNetworkService
         TestHelper.setExpectationEvent(EventType.CONFIGURATION, EventSource.REQUEST_CONTENT, 1)
@@ -71,7 +69,7 @@ class ConfigOverridesFunctionalTests {
 
     @After
     fun tearDown() {
-        mockNetworkService.reset()
+        resetTestExpectations()
     }
 
     // --------------------------------------------------------------------------------------------

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/ConsentStatusChangeFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/ConsentStatusChangeFunctionalTests.java
@@ -86,7 +86,7 @@ public class ConsentStatusChangeFunctionalTests {
 
 	@After
 	public void tearDown() {
-		mockNetworkService.reset();
+		resetTestExpectations();
 	}
 
 	// Test sendNetworkRequest(final EdgeHit edgeHit, final Map<String, String> requestHeaders, final int attemptCount)

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeFunctionalTests.java
@@ -115,7 +115,7 @@ public class EdgeFunctionalTests {
 
 	@After
 	public void tearDown() {
-		mockNetworkService.reset();
+		resetTestExpectations();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgePathOverwriteTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgePathOverwriteTests.java
@@ -86,7 +86,7 @@ public class EdgePathOverwriteTests {
 
 	@After
 	public void tearDown() {
-		mockNetworkService.reset();
+		resetTestExpectations();
 	}
 
 	@Test
@@ -342,5 +342,10 @@ public class EdgePathOverwriteTests {
 		assertTrue(networkRequest.getUrl().startsWith(EXEDGE_MEDIA_OR2_LOC_URL_STRING));
 		assertEquals(CONFIG_ID, networkRequest.queryParam("configId"));
 		assertNotNull(networkRequest.queryParam("requestId"));
+	}
+
+	private void resetTestExpectations() {
+		mockNetworkService.reset();
+		TestHelper.resetTestExpectations();
 	}
 }

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/IdentityStateFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/IdentityStateFunctionalTests.java
@@ -31,6 +31,7 @@ import com.adobe.marketing.mobile.util.KeyMustBeAbsent;
 import com.adobe.marketing.mobile.util.MockNetworkService;
 import com.adobe.marketing.mobile.util.MonitorExtension;
 import com.adobe.marketing.mobile.util.TestConstants;
+import com.adobe.marketing.mobile.util.TestHelper;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -83,7 +84,7 @@ public class IdentityStateFunctionalTests {
 
 	@After
 	public void tearDown() {
-		mockNetworkService.reset();
+		resetTestExpectations();
 	}
 
 	@Test
@@ -218,5 +219,10 @@ public class IdentityStateFunctionalTests {
 		);
 		assertEquals(1, requests.size());
 		assertExactMatch("{}", requests.get(0).getBodyJson(), new KeyMustBeAbsent("xdm.identityMap.ECID[0].id"));
+	}
+
+	private void resetTestExpectations() {
+		mockNetworkService.reset();
+		TestHelper.resetTestExpectations();
 	}
 }

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NoConfigFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NoConfigFunctionalTests.java
@@ -76,7 +76,7 @@ public class NoConfigFunctionalTests {
 
 	@After
 	public void tearDown() {
-		mockNetworkService.reset();
+		resetTestExpectations();
 	}
 
 	@Test

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/SampleFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/SampleFunctionalTests.java
@@ -14,6 +14,8 @@ package com.adobe.marketing.mobile;
 import static com.adobe.marketing.mobile.services.HttpMethod.POST;
 import static com.adobe.marketing.mobile.util.JSONAsserts.assertExactMatch;
 import static com.adobe.marketing.mobile.util.NodeConfig.Scope.Subtree;
+import static com.adobe.marketing.mobile.util.TestHelper.assertExpectedEvents;
+import static com.adobe.marketing.mobile.util.TestHelper.resetTestExpectations;
 import static org.junit.Assert.assertEquals;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -90,15 +92,13 @@ public class SampleFunctionalTests {
 		);
 		latch.await();
 
-		// Wait for and verify all expected events are received
-		TestHelper.assertExpectedEvents(false);
-		mockNetworkService.reset();
-		TestHelper.resetTestExpectations();
+		assertExpectedEvents(false);
+		resetTestExpectations();
 	}
 
 	@After
 	public void tearDown() {
-		mockNetworkService.reset();
+		resetTestExpectations();
 	}
 
 	@Test
@@ -220,5 +220,10 @@ public class SampleFunctionalTests {
 			"}";
 		assertExactMatch(expected, requests.get(0).getBodyJson());
 		TestHelper.assertExpectedEvents(true);
+	}
+
+	private void resetTestExpectations() {
+		mockNetworkService.reset();
+		TestHelper.resetTestExpectations();
 	}
 }


### PR DESCRIPTION
Update After tear down to call local resetTestExpections() methods, it includes mockNetworkService.reset and TestUtils.resetTestExpections()

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
