### PR TITLE
Update recoverable error codes

### DIFF
--- a/code/app-kotlin/build.gradle.kts
+++ b/code/app-kotlin/build.gradle.kts
@@ -78,9 +78,7 @@ dependencies {
 
     implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion")
     implementation("com.adobe.marketing.mobile:edgeidentity:$mavenEdgeIdentityVersion")
-    implementation("com.adobe.marketing.mobile:edgeconsent:$mavenEdgeConsentVersion") {
-        exclude(group = "com.adobe.marketing.mobile", module = "edge")
-    }
+    implementation("com.adobe.marketing.mobile:edgeconsent:3.0.0")
     implementation("com.adobe.marketing.mobile:assurance:3.0.0")
 
     implementation("androidx.constraintlayout:constraintlayout:2.0.4")

--- a/code/app/build.gradle.kts
+++ b/code/app/build.gradle.kts
@@ -75,9 +75,7 @@ dependencies {
 
     implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion")
     implementation("com.adobe.marketing.mobile:edgeidentity:$mavenEdgeIdentityVersion")
-    implementation("com.adobe.marketing.mobile:edgeconsent:$mavenEdgeConsentVersion") {
-        exclude(group = "com.adobe.marketing.mobile", module = "edge")
-    }
+    implementation("com.adobe.marketing.mobile:edgeconsent:3.0.0")
     implementation("com.adobe.marketing.mobile:assurance:3.0.0")
 
     implementation("androidx.constraintlayout:constraintlayout:2.0.4")

--- a/code/edge/build.gradle.kts
+++ b/code/edge/build.gradle.kts
@@ -39,8 +39,5 @@ dependencies {
     testImplementation("com.github.adobe:aepsdk-testutils-android:$mavenTestUtilsVersion")
 
     androidTestImplementation("com.github.adobe:aepsdk-testutils-android:$mavenTestUtilsVersion")
-    androidTestImplementation("com.adobe.marketing.mobile:edgeconsent:$mavenEdgeConsentVersion")
-    {
-        exclude(group = "com.adobe.marketing.mobile", module = "edge")
-    }
+    androidTestImplementation("com.adobe.marketing.mobile:edgeconsent:3.0.0")
 }

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeNetworkService.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeNetworkService.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -102,13 +101,14 @@ class EdgeNetworkService {
 		"Request to Edge Network failed with an unknown exception";
 
 	static final Set<Integer> recoverableNetworkErrorCodes = mergeUnique(
-            NetworkingConstants.RECOVERABLE_ERROR_CODES,
-            Arrays.asList(
-                    -1, // returned for SocketTimeoutException
-                    429, // too many requests - The user has sent too many requests in a given amount of time ("rate limiting").
-                    507, // insufficient storage
-                    HttpURLConnection.HTTP_BAD_GATEWAY
-            ));
+		NetworkingConstants.RECOVERABLE_ERROR_CODES,
+		Arrays.asList(
+			-1, // returned for SocketTimeoutException
+			429, // too many requests - The user has sent too many requests in a given amount of time ("rate limiting").
+			507, // insufficient storage
+			HttpURLConnection.HTTP_BAD_GATEWAY
+		)
+	);
 
 	private final Networking networkService;
 
@@ -262,7 +262,7 @@ class EdgeNetworkService {
 		int retryAfter = EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS;
 		if (header != null && header.matches("\\d+")) {
 			try {
-                retryAfter = Integer.parseInt(header);
+				retryAfter = Integer.parseInt(header);
 			} catch (NumberFormatException e) {
 				Log.debug(
 					LOG_TAG,
@@ -580,10 +580,10 @@ class EdgeNetworkService {
 		}
 	}
 
-    private static Set<Integer> mergeUnique(final List<Integer> arr1, final List<Integer> arr2) {
-        Set<Integer> merged = new HashSet<>();
-        merged.addAll(arr1);
-        merged.addAll(arr2);
-        return merged;
-    }
+	private static Set<Integer> mergeUnique(final List<Integer> arr1, final List<Integer> arr2) {
+		Set<Integer> merged = new HashSet<>();
+		merged.addAll(arr1);
+		merged.addAll(arr2);
+		return merged;
+	}
 }

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
@@ -412,7 +412,8 @@ public class EdgeNetworkServiceTest {
 		final Map<String, String> headers = new HashMap<>();
 		headers.put(HEADER_RETRY_AFTER, retryAfter);
 		MockConnection mockConnection = new MockConnection(responseCode, null, "error", headers);
-		mockNetworkService.mockConnectAsyncConnection = mockConnection;
+		mockNetworkService.reset();
+		mockNetworkService.setMockResponseFor(url, mockConnection);
 		networkService = new EdgeNetworkService(mockNetworkService);
 
 		// test

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
@@ -367,7 +367,7 @@ public class EdgeNetworkServiceTest {
 
 	@Test
 	public void testDoRequest_whenConnection_RecoverableResponseCode_507_ReturnsRetryYes_AndNoResponseCallback_AndNoErrorCallback() {
-		testRecoverableNetworkResponse(507, "Gateway Timeout");
+		testRecoverableNetworkResponse(507, "Insufficient Storage");
 	}
 
 	@Test
@@ -383,7 +383,7 @@ public class EdgeNetworkServiceTest {
 
 	@Test
 	public void testDoRequest_whenConnection_InvalidRetryAfter_ReturnsDefaultRetryTimeout() {
-		testRecoverableNetworkResponse(507, "Gateway Timeout");
+		testRecoverableNetworkResponse(507, "Insufficient Storage");
 		String[] invalidRetryAfter = { "InvalidRetryAfter", "A", "", "-1", "0", "     " };
 
 		for (String retryAfter : invalidRetryAfter) {
@@ -393,7 +393,7 @@ public class EdgeNetworkServiceTest {
 
 	@Test
 	public void testDoRequest_whenConnection_ValidRetryAfter_ReturnsCorrectRetryTimeout() {
-		testRecoverableNetworkResponse(507, "Gateway Timeout");
+		testRecoverableNetworkResponse(507, "Insufficient Storage");
 		String[] invalidRetryAfter = { "1", "5", "30", "60", "180", "300" };
 
 		for (String retryAfter : invalidRetryAfter) {

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
@@ -397,7 +397,7 @@ public class EdgeNetworkServiceTest {
 		String[] invalidRetryAfter = {"1", "5", "30", "60", "180", "300"};
 
 		for (String retryAfter : invalidRetryAfter) {
-			testRecoverableWithRetryAfter(503, retryAfter, Integer.parseInt(retryAfter)); // expecting default timeout
+			testRecoverableWithRetryAfter(503, retryAfter, Integer.parseInt(retryAfter)); // expecting provided timeout
 		}
 	}
 

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
@@ -384,7 +384,7 @@ public class EdgeNetworkServiceTest {
 	@Test
 	public void testDoRequest_whenConnection_InvalidRetryAfter_ReturnsDefaultRetryTimeout() {
 		testRecoverableNetworkResponse(507, "Gateway Timeout");
-		String[] invalidRetryAfter = {"InvalidRetryAfter", "A", "", "-1", "0", "     "};
+		String[] invalidRetryAfter = { "InvalidRetryAfter", "A", "", "-1", "0", "     " };
 
 		for (String retryAfter : invalidRetryAfter) {
 			testRecoverableWithRetryAfter(503, retryAfter, 5); // expecting default timeout
@@ -394,14 +394,18 @@ public class EdgeNetworkServiceTest {
 	@Test
 	public void testDoRequest_whenConnection_ValidRetryAfter_ReturnsCorrectRetryTimeout() {
 		testRecoverableNetworkResponse(507, "Gateway Timeout");
-		String[] invalidRetryAfter = {"1", "5", "30", "60", "180", "300"};
+		String[] invalidRetryAfter = { "1", "5", "30", "60", "180", "300" };
 
 		for (String retryAfter : invalidRetryAfter) {
 			testRecoverableWithRetryAfter(503, retryAfter, Integer.parseInt(retryAfter)); // expecting provided timeout
 		}
 	}
 
-	private void testRecoverableWithRetryAfter(final int responseCode, final String retryAfter, final int expectedRetryAfter) {
+	private void testRecoverableWithRetryAfter(
+		final int responseCode,
+		final String retryAfter,
+		final int expectedRetryAfter
+	) {
 		// setup
 		final String url = "https://test.com";
 		final String jsonRequest = "{}";

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
@@ -20,15 +20,19 @@ import static org.junit.Assert.fail;
 
 import com.adobe.marketing.mobile.services.HttpMethod;
 import com.adobe.marketing.mobile.services.NetworkRequest;
+import com.adobe.marketing.mobile.services.NetworkingConstants;
 import com.adobe.marketing.mobile.util.MockConnection;
 import com.adobe.marketing.mobile.util.MockNetworkService;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONException;
@@ -50,6 +54,7 @@ public class EdgeNetworkServiceTest {
 	private static final String TEST_URL = "https://test.com";
 	private static final String HEADER_CONTENT_TYPE = "Content-Type";
 	private static final String HEADER_CONTENT_TYPE_JSON_VALUE = "application/json";
+	private static final String HEADER_RETRY_AFTER = "Retry-After";
 	private final Map<String, String> requestHeaders = new HashMap<String, String>() {
 		{
 			put("key1", "value1");
@@ -358,6 +363,60 @@ public class EdgeNetworkServiceTest {
 	@Test
 	public void testDoRequest_whenConnection_RecoverableResponseCode_504_ReturnsRetryYes_AndNoResponseCallback_AndNoErrorCallback() {
 		testRecoverableNetworkResponse(504, "Gateway Timeout");
+	}
+
+	@Test
+	public void testDoRequest_whenConnection_RecoverableResponseCode_507_ReturnsRetryYes_AndNoResponseCallback_AndNoErrorCallback() {
+		testRecoverableNetworkResponse(507, "Gateway Timeout");
+	}
+
+	@Test
+	public void testDoRequest_whenConnection_RecoverableResponseCodeAndRetryAfter_ReturnsRetryTimeout() {
+		Set<Integer> recoverableNetworkErrorCodes = new HashSet<>();
+		recoverableNetworkErrorCodes.addAll(NetworkingConstants.RECOVERABLE_ERROR_CODES);
+		recoverableNetworkErrorCodes.addAll(Arrays.asList(429, 502, 507, -1));
+
+		for (int responseCode : recoverableNetworkErrorCodes) {
+			testRecoverableWithRetryAfter(responseCode, "30", 30);
+		}
+	}
+
+	@Test
+	public void testDoRequest_whenConnection_InvalidRetryAfter_ReturnsDefaultRetryTimeout() {
+		testRecoverableNetworkResponse(507, "Gateway Timeout");
+		String[] invalidRetryAfter = {"InvalidRetryAfter", "A", "", "-1", "0", "     "};
+
+		for (String retryAfter : invalidRetryAfter) {
+			testRecoverableWithRetryAfter(503, retryAfter, 5); // expecting default timeout
+		}
+	}
+
+	@Test
+	public void testDoRequest_whenConnection_ValidRetryAfter_ReturnsCorrectRetryTimeout() {
+		testRecoverableNetworkResponse(507, "Gateway Timeout");
+		String[] invalidRetryAfter = {"1", "5", "30", "60", "180", "300"};
+
+		for (String retryAfter : invalidRetryAfter) {
+			testRecoverableWithRetryAfter(503, retryAfter, Integer.parseInt(retryAfter)); // expecting default timeout
+		}
+	}
+
+	private void testRecoverableWithRetryAfter(final int responseCode, final String retryAfter, final int expectedRetryAfter) {
+		// setup
+		final String url = "https://test.com";
+		final String jsonRequest = "{}";
+		final Map<String, String> headers = new HashMap<>();
+		headers.put(HEADER_RETRY_AFTER, retryAfter);
+		MockConnection mockConnection = new MockConnection(responseCode, null, "error", headers);
+		mockNetworkService.mockConnectAsyncConnection = mockConnection;
+		networkService = new EdgeNetworkService(mockNetworkService);
+
+		// test
+		DoRequestResult result = doRequestSync(url, jsonRequest);
+
+		// verify
+		assertEquals(EdgeNetworkService.Retry.YES, result.retryResult.getShouldRetry());
+		assertEquals(expectedRetryAfter, result.retryResult.getRetryIntervalSeconds());
 	}
 
 	private void testRecoverableNetworkResponse(final int responseCode, final String errorString) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Adds 507 as recoverable error code as per contract with the Edge server implementation
- Uses NetworkingConstants.RECOVERABLE_ERROR_CODES as the base of error codes and add additional ones specific to Edge
- Checks Retry-After value is greater than 0, otherwise applies the default timeout.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
