### PR TITLE
Edge Event Batching implementation

### DIFF
--- a/code/app/src/main/java/com/adobe/marketing/mobile/edge/testapp/java/TestApplication.java
+++ b/code/app/src/main/java/com/adobe/marketing/mobile/edge/testapp/java/TestApplication.java
@@ -27,7 +27,7 @@ public class TestApplication extends Application {
 	private static final String LOG_SOURCE = "TestApplication";
 
 	// TODO: Set up the preferred Environment File ID from your mobile property configured in Data Collection UI
-	private final String ENVIRONMENT_FILE_ID = "";
+	private final String ENVIRONMENT_FILE_ID = "94f571f308d5/de953fa166e4/launch-f122c57f66ad-development";
 
 	@Override
 	public void onCreate() {

--- a/code/app/src/main/java/com/adobe/marketing/mobile/edge/testapp/java/TestApplication.java
+++ b/code/app/src/main/java/com/adobe/marketing/mobile/edge/testapp/java/TestApplication.java
@@ -27,7 +27,7 @@ public class TestApplication extends Application {
 	private static final String LOG_SOURCE = "TestApplication";
 
 	// TODO: Set up the preferred Environment File ID from your mobile property configured in Data Collection UI
-	private final String ENVIRONMENT_FILE_ID = "94f571f308d5/de953fa166e4/launch-f122c57f66ad-development";
+	private final String ENVIRONMENT_FILE_ID = "";
 
 	@Override
 	public void onCreate() {

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/CompletionHandlerFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/CompletionHandlerFunctionalTests.java
@@ -54,6 +54,9 @@ public class CompletionHandlerFunctionalTests {
 	private static final String RESPONSE_BODY_WITH_TWO_ERRORS =
 		"\u0000{\"requestId\": \"0ee43289-4a4e-469a-bf5c-1d8186919a27\",\"errors\": [{\"message\": \"An error occurred while calling the 'X' service for this request. Please try again.\", \"code\": \"502\"}, {\"message\": \"An error occurred while calling the 'Y', service unavailable\", \"code\": \"503\"}]}\n";
 
+	private static final String RESPONSE_BODY_WITH_EVENT_ERROR =
+		"\u0000{\"requestId\": \"0ee43289-4a4e-469a-bf5c-1d8186919a28\",\"handle\": [],\"errors\": [{\"type\": \"https://ns.adobe.com/aep/errors/EXEG-0201-503\",\"status\": 503,\"title\": \"Service Unavailable\",\"detail\": \"The service is temporarily unavailable\",\"report\": {\"eventIndex\": 0}}]}\n";
+
 	@Rule
 	public RuleChain rule = RuleChain.outerRule(new LogOnErrorRule()).around(new SetupCoreRule());
 
@@ -329,6 +332,65 @@ public class CompletionHandlerFunctionalTests {
 		mockNetworkService.assertAllNetworkRequestExpectations();
 		assertTrue("Timeout waiting for EdgeCallback completion handler.", latch1.await(1, TimeUnit.SECONDS));
 		assertTrue("Timeout waiting for EdgeCallback completion handler.", latch2.await(1, TimeUnit.SECONDS));
+	}
+
+	@Test
+	public void testSendEvent_withEdgeCallbackWithError_whenServerReturnsEventError_deliversOnError()
+		throws InterruptedException {
+		HttpConnecting responseConnection = mockNetworkService.createMockNetworkResponse(
+			RESPONSE_BODY_WITH_EVENT_ERROR,
+			200
+		);
+		mockNetworkService.setMockResponseFor(EXEDGE_INTERACT_URL_STRING, POST, responseConnection);
+		mockNetworkService.setExpectationForNetworkRequest(EXEDGE_INTERACT_URL_STRING, POST, 1);
+
+		ExperienceEvent experienceEvent = new ExperienceEvent.Builder()
+			.setXdmSchema(
+				new HashMap<String, Object>() {
+					{
+						put("eventType", "personalizationEvent");
+						put("test", "xdm");
+					}
+				}
+			)
+			.build();
+
+		final CountDownLatch completeLatch = new CountDownLatch(1);
+		final CountDownLatch errorLatch = new CountDownLatch(1);
+		final List<EdgeEventHandle> receivedHandles = new ArrayList<>();
+		final List<EdgeEventError> receivedErrors = new ArrayList<>();
+
+		// Exercises the new Edge.sendEvent(ExperienceEvent, EdgeCallbackWithError) overload end-to-end:
+		// server event error → NetworkResponseHandler.buildEdgeEventError → CompletionCallbacksManager
+		// → EdgeCallbackWithError.onError.
+		Edge.sendEvent(
+			experienceEvent,
+			new EdgeCallbackWithError() {
+				@Override
+				public void onComplete(final List<EdgeEventHandle> handles) {
+					receivedHandles.addAll(handles);
+					completeLatch.countDown();
+				}
+
+				@Override
+				public void onError(final List<EdgeEventError> errors) {
+					receivedErrors.addAll(errors);
+					errorLatch.countDown();
+				}
+			}
+		);
+
+		mockNetworkService.assertAllNetworkRequestExpectations();
+		assertTrue("Timeout waiting for onComplete.", completeLatch.await(1, TimeUnit.SECONDS));
+		assertTrue("Timeout waiting for onError.", errorLatch.await(1, TimeUnit.SECONDS));
+
+		assertEquals(0, receivedHandles.size());
+		assertEquals(1, receivedErrors.size());
+		EdgeEventError error = receivedErrors.get(0);
+		assertEquals("https://ns.adobe.com/aep/errors/EXEG-0201-503", error.getType());
+		assertEquals(503, error.getStatus());
+		assertEquals("Service Unavailable", error.getTitle());
+		assertEquals("The service is temporarily unavailable", error.getDetail());
 	}
 
 	/**

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeBatchingFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeBatchingFunctionalTests.java
@@ -245,7 +245,9 @@ public class EdgeBatchingFunctionalTests {
 		config.put("edge.batching.enabled", enabled);
 		config.put("edge.batching.eventNameAllowlist", allowlist);
 		MobileCore.updateConfiguration(config);
-		assertExpectedEvents(false);
+		// Wait for the configuration response (barrier: config shared state is now applied), ignoring the
+		// other events updateConfiguration also emits (CONFIGURATION request, HUB shared state).
+		assertExpectedEvents(true);
 		resetTestExpectations();
 	}
 

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeBatchingFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/EdgeBatchingFunctionalTests.java
@@ -1,0 +1,267 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile;
+
+import static com.adobe.marketing.mobile.services.HttpMethod.POST;
+import static com.adobe.marketing.mobile.util.TestHelper.LogOnErrorRule;
+import static com.adobe.marketing.mobile.util.TestHelper.SetupCoreRule;
+import static com.adobe.marketing.mobile.util.TestHelper.assertExpectedEvents;
+import static com.adobe.marketing.mobile.util.TestHelper.resetTestExpectations;
+import static com.adobe.marketing.mobile.util.TestHelper.setExpectationEvent;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.adobe.marketing.mobile.edge.identity.Identity;
+import com.adobe.marketing.mobile.services.HttpConnecting;
+import com.adobe.marketing.mobile.services.ServiceProvider;
+import com.adobe.marketing.mobile.services.TestableNetworkRequest;
+import com.adobe.marketing.mobile.util.MockNetworkService;
+import com.adobe.marketing.mobile.util.MonitorExtension;
+import com.adobe.marketing.mobile.util.TestConstants;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+
+/**
+ * End-to-end functional coverage for Experience Event batching: config plumbing through the real
+ * {@link EdgeExtension} / {@link EdgeBatchingHitQueue}, allowlist gating, the non-batching (default)
+ * path, and per-event completion-callback consistency when a batch is coalesced into one request.
+ *
+ * <p>Batching is timing-sensitive: a batch only forms when more than one event is queued before a
+ * processing cycle sends the head. These tests make batch formation deterministic with
+ * {@link MockNetworkService#enableNetworkResponseDelay(int)}, which blocks the queue's single worker
+ * thread inside the first network call long enough for the remaining events to enqueue and coalesce
+ * on the next cycle. Assertions are written to hold regardless of exactly how the events distribute
+ * across the (1 or 2) resulting requests, so they are not flaky.
+ *
+ * <p>All events are sent via {@link Edge#sendEvent}, which names the dispatched Edge request event
+ * {@code "AEP Request Event"} — hence the allowlist value used here.
+ */
+@RunWith(AndroidJUnit4.class)
+public class EdgeBatchingFunctionalTests {
+
+	private static final MockNetworkService mockNetworkService = new MockNetworkService();
+	private static final String EXEDGE_INTERACT_URL_STRING = TestConstants.Defaults.EXEDGE_INTERACT_URL_STRING;
+	private static final String CONFIG_ID = "1234abcd-abcd-1234-5678-123456abcdef";
+
+	// Name of the Edge request event dispatched by Edge.sendEvent (EdgeConstants.EventName.REQUEST_CONTENT).
+	private static final String EDGE_REQUEST_EVENT_NAME = "AEP Request Event";
+
+	@Rule
+	public RuleChain rule = RuleChain.outerRule(new LogOnErrorRule()).around(new SetupCoreRule());
+
+	@Before
+	public void setup() throws Exception {
+		ServiceProvider.getInstance().setNetworkService(mockNetworkService);
+
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.REQUEST_CONTENT, 1);
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT, 1);
+		setExpectationEvent(EventType.HUB, EventSource.SHARED_STATE, 4); // Edge, Config, Identity, Hub
+
+		HashMap<String, Object> config = new HashMap<String, Object>() {
+			{
+				put("edge.configId", CONFIG_ID);
+			}
+		};
+		MobileCore.updateConfiguration(config);
+
+		final CountDownLatch latch = new CountDownLatch(1);
+		MobileCore.registerExtensions(
+			Arrays.asList(Edge.EXTENSION, Identity.EXTENSION, MonitorExtension.EXTENSION),
+			o -> latch.countDown()
+		);
+		latch.await();
+		assertExpectedEvents(false);
+		resetTestExpectations();
+	}
+
+	@After
+	public void tearDown() {
+		mockNetworkService.reset();
+	}
+
+	// -------------------------------------------------------------------------
+	// Non-batching (default) — regression guard for users who never enable batching
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testBatchingDisabled_multipleEvents_sentAsIndividualRequests() throws InterruptedException {
+		setDefaultResponse();
+
+		final CountDownLatch callbacks = sendEvents(3);
+
+		assertTrue("Timeout waiting for all event callbacks.", callbacks.await(5, TimeUnit.SECONDS));
+
+		final List<TestableNetworkRequest> requests = mockNetworkService.getNetworkRequestsWith(
+			EXEDGE_INTERACT_URL_STRING,
+			POST
+		);
+		// Batching off (default): one request per event, each carrying exactly one event.
+		assertEquals(3, requests.size());
+		for (final TestableNetworkRequest request : requests) {
+			assertEquals(1, eventCountInBody(request));
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Batching enabled + allowlisted — events coalesce into fewer requests
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testBatchingEnabledAndAllowlisted_multipleEvents_coalescedIntoFewerRequests()
+		throws InterruptedException {
+		applyBatchingConfig(true, Arrays.asList(EDGE_REQUEST_EVENT_NAME));
+		setDefaultResponse();
+		// Hold the first cycle in the network so the remaining events enqueue and coalesce.
+		mockNetworkService.enableNetworkResponseDelay(1);
+
+		final CountDownLatch callbacks = sendEvents(3);
+
+		assertTrue("Timeout waiting for all event callbacks.", callbacks.await(10, TimeUnit.SECONDS));
+
+		final List<TestableNetworkRequest> requests = mockNetworkService.getNetworkRequestsWith(
+			EXEDGE_INTERACT_URL_STRING,
+			POST
+		);
+
+		// Batching happened → fewer requests than events, and at least one request carries > 1 event.
+		assertTrue("Expected fewer requests than events when batching, got " + requests.size(), requests.size() < 3);
+
+		int totalEvents = 0;
+		int maxEventsInOneRequest = 0;
+		for (final TestableNetworkRequest request : requests) {
+			final int count = eventCountInBody(request);
+			totalEvents += count;
+			maxEventsInOneRequest = Math.max(maxEventsInOneRequest, count);
+		}
+		// No event is lost or duplicated regardless of how they distribute across requests.
+		assertEquals(3, totalEvents);
+		assertTrue("Expected at least one coalesced request with >1 event.", maxEventsInOneRequest > 1);
+		// Every event's completion callback still fired exactly once (per-event completion consistency).
+	}
+
+	// -------------------------------------------------------------------------
+	// Batching enabled but event name not allowlisted — allowlist gate
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testBatchingEnabledButNotAllowlisted_multipleEvents_sentAsIndividualRequests()
+		throws InterruptedException {
+		applyBatchingConfig(true, Arrays.asList("some.other.event.name"));
+		setDefaultResponse();
+
+		final CountDownLatch callbacks = sendEvents(3);
+
+		assertTrue("Timeout waiting for all event callbacks.", callbacks.await(5, TimeUnit.SECONDS));
+
+		final List<TestableNetworkRequest> requests = mockNetworkService.getNetworkRequestsWith(
+			EXEDGE_INTERACT_URL_STRING,
+			POST
+		);
+		// Batching enabled but the event name is not allowlisted → still one event per request.
+		assertEquals(3, requests.size());
+		for (final TestableNetworkRequest request : requests) {
+			assertEquals(1, eventCountInBody(request));
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Batching + server error — each batched event still completes its callback
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testBatchingEnabledAndAllowlisted_serverError_stillCompletesEachEventCallback()
+		throws InterruptedException {
+		applyBatchingConfig(true, Arrays.asList(EDGE_REQUEST_EVENT_NAME));
+		// Non-recoverable server error for every request; each event must still complete its callback.
+		final HttpConnecting errorResponse = mockNetworkService.createMockNetworkResponse(
+			"{\"type\":\"https://ns.adobe.com/aep/errors/EXEG-0104-422\",\"status\":422,\"title\":\"Unprocessable\"}",
+			422
+		);
+		mockNetworkService.setMockResponseFor(EXEDGE_INTERACT_URL_STRING, POST, errorResponse);
+		mockNetworkService.enableNetworkResponseDelay(1);
+
+		final CountDownLatch callbacks = sendEvents(3);
+
+		// Every event's completion callback fires even though the batch got a non-recoverable error.
+		assertTrue(
+			"Timeout waiting for all event callbacks after server error.",
+			callbacks.await(10, TimeUnit.SECONDS)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Sends {@code count} identical Experience Events and returns a latch that reaches zero once every
+	 * event's completion callback has fired.
+	 */
+	private CountDownLatch sendEvents(final int count) {
+		final CountDownLatch latch = new CountDownLatch(count);
+		final AtomicInteger index = new AtomicInteger(0);
+		for (int i = 0; i < count; i++) {
+			final int n = index.getAndIncrement();
+			final ExperienceEvent experienceEvent = new ExperienceEvent.Builder()
+				.setXdmSchema(
+					new HashMap<String, Object>() {
+						{
+							put("eventType", "batchingFunctionalTest");
+							put("index", n);
+						}
+					}
+				)
+				.build();
+			Edge.sendEvent(experienceEvent, handles -> latch.countDown());
+		}
+		return latch;
+	}
+
+	/** Merges the batching keys into the Configuration shared state and waits for it to apply. */
+	private void applyBatchingConfig(final boolean enabled, final List<String> allowlist) throws InterruptedException {
+		setExpectationEvent(EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT, 1);
+		final HashMap<String, Object> config = new HashMap<>();
+		config.put("edge.batching.enabled", enabled);
+		config.put("edge.batching.eventNameAllowlist", allowlist);
+		MobileCore.updateConfiguration(config);
+		assertExpectedEvents(false);
+		resetTestExpectations();
+	}
+
+	private void setDefaultResponse() {
+		final HttpConnecting response = mockNetworkService.createMockNetworkResponse("{}", 200);
+		mockNetworkService.setMockResponseFor(EXEDGE_INTERACT_URL_STRING, POST, response);
+	}
+
+	/** Parses a recorded request body and returns the number of events in its {@code events} array. */
+	private int eventCountInBody(final TestableNetworkRequest request) {
+		try {
+			final String body = new String(request.getBody());
+			final JSONObject json = new JSONObject(body);
+			return json.getJSONArray("events").length();
+		} catch (final Exception e) {
+			throw new AssertionError("Failed to parse request body as JSON with an 'events' array", e);
+		}
+	}
+}

--- a/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
+++ b/code/edge/src/androidTest/java/com/adobe/marketing/mobile/NetworkResponseHandlerFunctionalTests.java
@@ -704,6 +704,9 @@ public class NetworkResponseHandlerFunctionalTests {
 		dispatchEvents.addAll(getDispatchedEventsWith(EventType.EDGE, "pairedeventexample"));
 		assertEquals(2, dispatchEvents.size());
 
+		// The state:store handle carries no eventIndex and is a global (session-scoped) handle, so in a
+		// multi-event request it is broadcast rather than attributed to a specific event: no
+		// requestEventId in the data and a null parent id.
 		String expectedEventData1 =
 			"{" +
 			"  \"payload\": [" +
@@ -713,14 +716,11 @@ public class NetworkResponseHandlerFunctionalTests {
 			"      \"value\": \"MCMID|29068398647607325310376254630528178721\"" +
 			"    }" +
 			"  ]," +
-			"  \"requestEventId\": \"" +
-			event1.getUniqueIdentifier() +
-			"\"," +
 			"  \"requestId\": \"123\"," +
 			"  \"type\": \"state:store\"" +
 			"}";
 		JSONAsserts.assertEquals(expectedEventData1, dispatchEvents.get(0).getEventData());
-		assertEquals(event1.getUniqueIdentifier(), dispatchEvents.get(0).getParentID());
+		assertNull(dispatchEvents.get(0).getParentID());
 
 		// verify event 2
 		String expectedEventData2 =
@@ -844,7 +844,8 @@ public class NetworkResponseHandlerFunctionalTests {
 	@Test
 	public void testProcessResponseOnSuccess_WhenEventHandleAndError_dispatchesTwoEvents() throws InterruptedException {
 		setExpectationEvent(EventType.EDGE, EventSource.RESPONSE_CONTENT, 1);
-		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 1);
+		// The no-eventIndex error fans out to both waiting events, so two error events are dispatched.
+		setExpectationEvent(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT, 2);
 		final String requestId = "123";
 		final String jsonResponse =
 			"{\n" +
@@ -874,6 +875,9 @@ public class NetworkResponseHandlerFunctionalTests {
 		List<Event> dispatchEvents = getDispatchedEventsWith(EventType.EDGE, "state:store");
 		assertEquals(1, dispatchEvents.size());
 
+		// The state:store handle carries no eventIndex and is a global (session-scoped) handle, so in a
+		// multi-event request it is broadcast rather than attributed to a specific event: no
+		// requestEventId in the data and a null parent id.
 		String expectedEventData1 =
 			"{" +
 			"  \"payload\": [" +
@@ -883,20 +887,19 @@ public class NetworkResponseHandlerFunctionalTests {
 			"      \"value\": \"MCMID|29068398647607325310376254630528178721\"" +
 			"    }" +
 			"  ]," +
-			"  \"requestEventId\": \"" +
-			event1.getUniqueIdentifier() +
-			"\"," +
 			"  \"requestId\": \"123\"," +
 			"  \"type\": \"state:store\"" +
 			"}";
 
 		JSONAsserts.assertEquals(expectedEventData1, dispatchEvents.get(0).getEventData());
-		assertEquals(event1.getUniqueIdentifier(), dispatchEvents.get(0).getParentID());
+		assertNull(dispatchEvents.get(0).getParentID());
 
+		// The error carries no eventIndex — a root-level error means the whole batch failed, so it is
+		// dispatched once per waiting event (each caller learns their event failed).
 		List<Event> dispatchErrorEvents = getDispatchedEventsWith(EventType.EDGE, EventSource.ERROR_RESPONSE_CONTENT);
-		assertEquals(1, dispatchErrorEvents.size());
+		assertEquals(2, dispatchErrorEvents.size());
 
-		String expectedEventData2 =
+		String expectedErrorForEvent1 =
 			"{" +
 			"  \"requestEventId\": \"" +
 			event1.getUniqueIdentifier() +
@@ -906,8 +909,21 @@ public class NetworkResponseHandlerFunctionalTests {
 			"  \"title\": \"Failed to process personalization event\"," +
 			"  \"type\": \"personalization\"" +
 			"}";
-		JSONAsserts.assertEquals(expectedEventData2, dispatchErrorEvents.get(0).getEventData());
+		JSONAsserts.assertEquals(expectedErrorForEvent1, dispatchErrorEvents.get(0).getEventData());
 		assertEquals(event1.getUniqueIdentifier(), dispatchErrorEvents.get(0).getParentID());
+
+		String expectedErrorForEvent2 =
+			"{" +
+			"  \"requestEventId\": \"" +
+			event2.getUniqueIdentifier() +
+			"\"," +
+			"  \"requestId\": \"123\"," +
+			"  \"status\": 2003," +
+			"  \"title\": \"Failed to process personalization event\"," +
+			"  \"type\": \"personalization\"" +
+			"}";
+		JSONAsserts.assertEquals(expectedErrorForEvent2, dispatchErrorEvents.get(1).getEventData());
+		assertEquals(event2.getUniqueIdentifier(), dispatchErrorEvents.get(1).getParentID());
 	}
 
 	@Test

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/BatchOutcome.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/BatchOutcome.java
@@ -18,8 +18,12 @@ package com.adobe.marketing.mobile;
 class BatchOutcome {
 
 	enum Kind {
-		/** All entities in the batch were resolved (delivered, dropped with error, or ingested).
-		 *  Remove the whole batch from the queue. */
+		/** The first {@link #resolvedHeadCount} entities (from the head) were resolved (delivered,
+		 *  dropped with error, or ingested). Remove exactly that many from the queue — {@code
+		 *  processBatch} may have been given a larger peeked window than it actually resolved (e.g. a
+		 *  window truncated at a Consent/Reset/decode-failure boundary, or a single non-ExperienceEvent
+		 *  head processed alone); only the resolved prefix is safe to dequeue. Anything beyond it was
+		 *  never sent and must stay queued for the next cycle. */
 		DONE,
 
 		/** A recoverable network error occurred; nothing was ingested.
@@ -41,8 +45,15 @@ class BatchOutcome {
 		this.resolvedHeadCount = resolvedHeadCount;
 	}
 
-	static BatchOutcome done() {
-		return new BatchOutcome(Kind.DONE, 0, 0);
+	/**
+	 * @param resolvedCount the number of entities, counted from the head of the window {@code
+	 *     processBatch} was given, that were actually resolved (sent/dropped) and are therefore safe
+	 *     to remove from the queue. Must never exceed the size of the window passed to {@code
+	 *     processBatch} — pass the count of entities actually acted upon, not the full peeked window,
+	 *     whenever the two can differ (truncation, single-entity delegation, decode failure).
+	 */
+	static BatchOutcome done(final int resolvedCount) {
+		return new BatchOutcome(Kind.DONE, 0, resolvedCount);
 	}
 
 	static BatchOutcome retryBatch(final int retryAfterSeconds) {

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/BatchOutcome.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/BatchOutcome.java
@@ -14,73 +14,90 @@ package com.adobe.marketing.mobile;
 /**
  * Result returned by {@link EdgeHitProcessor#processBatch} to tell
  * {@link EdgeBatchingHitQueue} how to advance the queue after a batch attempt.
+ *
+ * <p>Every outcome is exactly one {@link Kind} plus the single integer that kind carries — never a
+ * combination, so there is no risk of reading the wrong field for the current outcome.
+ * {@link EdgeBatchingHitQueue} switches on {@link #getKind()} to act on it.
  */
 class BatchOutcome {
 
+	/** What happened, and what {@link BatchOutcome#getValue()} means for it. */
 	enum Kind {
-		/** The first {@link #resolvedHeadCount} entities (from the head) were resolved (delivered,
-		 *  dropped with error, or ingested). Remove exactly that many from the queue — {@code
-		 *  processBatch} may have been given a larger peeked window than it actually resolved (e.g. a
-		 *  window truncated at a Consent/Reset/decode-failure boundary, or a single non-ExperienceEvent
-		 *  head processed alone); only the resolved prefix is safe to dequeue. Anything beyond it was
-		 *  never sent and must stay queued for the next cycle. */
+		/** {@code value} = number of entities resolved from the head of the queue; safe to remove. */
 		DONE,
-
-		/** A recoverable network error occurred; nothing was ingested.
-		 *  Leave the entire batch in the queue and retry after {@link #retryAfterSeconds}. */
-		RETRY_BATCH,
-
-		/** A 400 explosion partially resolved the batch from the head.
-		 *  Remove the first {@link #resolvedHeadCount} entities; leave the rest for the next cycle. */
-		PARTIAL_REMOVE
+		/** {@code value} = seconds to wait before the next cycle; nothing removed. */
+		RETRY,
+		/** {@code value} = number of entities to drain one at a time via forced batch-size-1. */
+		EXPLODE
 	}
 
 	private final Kind kind;
-	private final int retryAfterSeconds;
-	private final int resolvedHeadCount;
+	private final int value;
 
-	private BatchOutcome(final Kind kind, final int retryAfterSeconds, final int resolvedHeadCount) {
+	private BatchOutcome(final Kind kind, final int value) {
 		this.kind = kind;
-		this.retryAfterSeconds = retryAfterSeconds;
-		this.resolvedHeadCount = resolvedHeadCount;
+		this.value = value;
 	}
 
 	/**
-	 * @param resolvedCount the number of entities, counted from the head of the window {@code
-	 *     processBatch} was given, that were actually resolved (sent/dropped) and are therefore safe
-	 *     to remove from the queue. Must never exceed the size of the window passed to {@code
-	 *     processBatch} — pass the count of entities actually acted upon, not the full peeked window,
-	 *     whenever the two can differ (truncation, single-entity delegation, decode failure).
+	 * The first {@code resolvedCount} entities (from the head) were resolved (delivered, dropped with
+	 * error, or ingested). Remove exactly that many and process the next cycle immediately — {@code
+	 * processBatch} may have been given a larger peeked window than it acted on (truncation at a
+	 * Consent/Reset/decode-failure/allowlist/config-mismatch boundary, or a single non-batchable head
+	 * processed alone); anything beyond the resolved prefix was never sent and must stay queued for the
+	 * next cycle.
+	 *
+	 * @param resolvedCount number of head entities safe to remove; never more than the window size.
 	 */
 	static BatchOutcome done(final int resolvedCount) {
-		return new BatchOutcome(Kind.DONE, 0, resolvedCount);
-	}
-
-	static BatchOutcome retryBatch(final int retryAfterSeconds) {
-		return new BatchOutcome(Kind.RETRY_BATCH, retryAfterSeconds, 0);
-	}
-
-	static BatchOutcome partialRemove(final int resolvedHeadCount) {
-		return new BatchOutcome(Kind.PARTIAL_REMOVE, 0, resolvedHeadCount);
+		return new BatchOutcome(Kind.DONE, resolvedCount);
 	}
 
 	/**
-	 * Variant used when the failed entity at the new queue head needs a retry delay before
-	 * the next cycle — e.g. after partial explosion where the next entity returned a recoverable error.
+	 * A recoverable network error occurred; nothing was ingested. Remove nothing (the whole batch
+	 * stays queued) and retry after {@code retryDelaySeconds}.
 	 */
-	static BatchOutcome partialRemove(final int resolvedHeadCount, final int retryAfterSeconds) {
-		return new BatchOutcome(Kind.PARTIAL_REMOVE, retryAfterSeconds, resolvedHeadCount);
+	static BatchOutcome retryBatch(final int retryDelaySeconds) {
+		return new BatchOutcome(Kind.RETRY, retryDelaySeconds);
 	}
 
+	/**
+	 * A batch of {@code count} events got a 400 — nothing was ingested. Remove nothing yet; instead
+	 * tell the queue to drain exactly these {@code count} entities one at a time (via the ordinary
+	 * single-event path) before resuming normal batch-sized peeking. See
+	 * {@link EdgeBatchingHitQueue#runBatchCycle()}.
+	 *
+	 * @param count number of entities in the batch that must now be drained individually
+	 */
+	static BatchOutcome explode(final int count) {
+		return new BatchOutcome(Kind.EXPLODE, count);
+	}
+
+	/** Which case this outcome represents; determines what {@link #getValue()} means. */
 	Kind getKind() {
 		return kind;
 	}
 
-	int getRetryAfterSeconds() {
-		return retryAfterSeconds;
+	/** The single integer this outcome carries; see {@link Kind} for what it means per case. */
+	int getValue() {
+		return value;
 	}
 
-	int getResolvedHeadCount() {
-		return resolvedHeadCount;
+	/** Number of entities to remove from the head of the queue after this attempt; 0 unless {@link Kind#DONE}. */
+	int getRemoveCount() {
+		return kind == Kind.DONE ? value : 0;
+	}
+
+	/** Seconds to wait before the next processing cycle; 0 unless {@link Kind#RETRY}. */
+	int getRetryDelaySeconds() {
+		return kind == Kind.RETRY ? value : 0;
+	}
+
+	/**
+	 * Number of entities that must be drained one at a time before batch-sized peeking resumes; 0
+	 * unless {@link Kind#EXPLODE}.
+	 */
+	int getExplodeCount() {
+		return kind == Kind.EXPLODE ? value : 0;
 	}
 }

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/BatchOutcome.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/BatchOutcome.java
@@ -28,7 +28,7 @@ class BatchOutcome {
 		/** {@code value} = seconds to wait before the next cycle; nothing removed. */
 		RETRY,
 		/** {@code value} = number of entities to drain one at a time via forced batch-size-1. */
-		EXPLODE
+		EXPLODE,
 	}
 
 	private final Kind kind;
@@ -65,7 +65,6 @@ class BatchOutcome {
 	 * A batch of {@code count} events got a 400 — nothing was ingested. Remove nothing yet; instead
 	 * tell the queue to drain exactly these {@code count} entities one at a time (via the ordinary
 	 * single-event path) before resuming normal batch-sized peeking. See
-	 * {@link EdgeBatchingHitQueue#runBatchCycle()}.
 	 *
 	 * @param count number of entities in the batch that must now be drained individually
 	 */

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/BatchOutcome.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/BatchOutcome.java
@@ -1,0 +1,75 @@
+/*
+  Copyright 2019 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile;
+
+/**
+ * Result returned by {@link EdgeHitProcessor#processBatch} to tell
+ * {@link EdgeBatchingHitQueue} how to advance the queue after a batch attempt.
+ */
+class BatchOutcome {
+
+	enum Kind {
+		/** All entities in the batch were resolved (delivered, dropped with error, or ingested).
+		 *  Remove the whole batch from the queue. */
+		DONE,
+
+		/** A recoverable network error occurred; nothing was ingested.
+		 *  Leave the entire batch in the queue and retry after {@link #retryAfterSeconds}. */
+		RETRY_BATCH,
+
+		/** A 400 explosion partially resolved the batch from the head.
+		 *  Remove the first {@link #resolvedHeadCount} entities; leave the rest for the next cycle. */
+		PARTIAL_REMOVE
+	}
+
+	private final Kind kind;
+	private final int retryAfterSeconds;
+	private final int resolvedHeadCount;
+
+	private BatchOutcome(final Kind kind, final int retryAfterSeconds, final int resolvedHeadCount) {
+		this.kind = kind;
+		this.retryAfterSeconds = retryAfterSeconds;
+		this.resolvedHeadCount = resolvedHeadCount;
+	}
+
+	static BatchOutcome done() {
+		return new BatchOutcome(Kind.DONE, 0, 0);
+	}
+
+	static BatchOutcome retryBatch(final int retryAfterSeconds) {
+		return new BatchOutcome(Kind.RETRY_BATCH, retryAfterSeconds, 0);
+	}
+
+	static BatchOutcome partialRemove(final int resolvedHeadCount) {
+		return new BatchOutcome(Kind.PARTIAL_REMOVE, 0, resolvedHeadCount);
+	}
+
+	/**
+	 * Variant used when the failed entity at the new queue head needs a retry delay before
+	 * the next cycle — e.g. after partial explosion where the next entity returned a recoverable error.
+	 */
+	static BatchOutcome partialRemove(final int resolvedHeadCount, final int retryAfterSeconds) {
+		return new BatchOutcome(Kind.PARTIAL_REMOVE, retryAfterSeconds, resolvedHeadCount);
+	}
+
+	Kind getKind() {
+		return kind;
+	}
+
+	int getRetryAfterSeconds() {
+		return retryAfterSeconds;
+	}
+
+	int getResolvedHeadCount() {
+		return resolvedHeadCount;
+	}
+}

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/BatchOutcome.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/BatchOutcome.java
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Adobe. All rights reserved.
+  Copyright 2026 Adobe. All rights reserved.
   This file is licensed to you under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License. You may obtain a copy
   of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/CompletionCallbacksManager.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/CompletionCallbacksManager.java
@@ -33,9 +33,13 @@ class CompletionCallbacksManager {
 	// edge response handles for a event request id (key)
 	private final ConcurrentMap<String, List<EdgeEventHandle>> edgeEventHandles;
 
+	// edge response errors for a event request id (key); only populated when callback is EdgeCallbackWithError
+	private final ConcurrentMap<String, List<EdgeEventError>> edgeEventErrors;
+
 	private CompletionCallbacksManager() {
 		completionCallbacks = new ConcurrentHashMap<>();
 		edgeEventHandles = new ConcurrentHashMap<>();
+		edgeEventErrors = new ConcurrentHashMap<>();
 	}
 
 	/**
@@ -91,6 +95,13 @@ class CompletionCallbacksManager {
 
 		if (callback != null) {
 			final List<EdgeEventHandle> handles = edgeEventHandles.get(requestEventId);
+			Log.debug(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Firing onComplete for event id %s with %d handle(s).",
+				requestEventId,
+				handles != null ? handles.size() : 0
+			);
 			try {
 				callback.onComplete(handles != null ? handles : new ArrayList<>());
 			} catch (Exception ex) {
@@ -102,6 +113,31 @@ class CompletionCallbacksManager {
 					android.util.Log.getStackTraceString(ex)
 				);
 			}
+
+			if (callback instanceof EdgeCallbackWithError) {
+				final List<EdgeEventError> errors = edgeEventErrors.get(requestEventId);
+				if (errors != null && !errors.isEmpty()) {
+					Log.debug(
+						LOG_TAG,
+						LOG_SOURCE,
+						"Firing onError for event id %s with %d error(s).",
+						requestEventId,
+						errors.size()
+					);
+					try {
+						((EdgeCallbackWithError) callback).onError(errors);
+					} catch (Exception ex) {
+						Log.warning(
+							LOG_TAG,
+							LOG_SOURCE,
+							"Exception thrown when invoking error callback for request event id %s: %s",
+							requestEventId,
+							android.util.Log.getStackTraceString(ex)
+						);
+					}
+				}
+			}
+
 			Log.trace(
 				LOG_TAG,
 				LOG_SOURCE,
@@ -110,6 +146,7 @@ class CompletionCallbacksManager {
 		}
 
 		edgeEventHandles.remove(requestEventId);
+		edgeEventErrors.remove(requestEventId);
 	}
 
 	/**
@@ -125,5 +162,22 @@ class CompletionCallbacksManager {
 
 		edgeEventHandles.putIfAbsent(requestEventId, new ArrayList<>());
 		edgeEventHandles.get(requestEventId).add(eventHandle);
+	}
+
+	/**
+	 * Accumulates an {@link EdgeEventError} for the given {@code requestEventId}. These errors are
+	 * delivered to the caller via {@link EdgeCallbackWithError#onError} when {@link #unregisterCallback}
+	 * is invoked.
+	 *
+	 * @param requestEventId the request event identifier associated with this error
+	 * @param error the error to accumulate
+	 */
+	void eventErrorReceived(final String requestEventId, final EdgeEventError error) {
+		if (StringUtils.isNullOrEmpty(requestEventId) || error == null) {
+			return;
+		}
+
+		edgeEventErrors.putIfAbsent(requestEventId, new ArrayList<>());
+		edgeEventErrors.get(requestEventId).add(error);
 	}
 }

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/Edge.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/Edge.java
@@ -88,6 +88,23 @@ public class Edge {
 	}
 
 	/**
+	 * Sends an event to Adobe Experience Edge and registers a callback for responses and per-event errors
+	 * coming from the Edge Network. Use this overload when you want to receive both response handles and
+	 * errors in the same callback object.
+	 *
+	 * @param experienceEvent event to be sent to Adobe Experience Edge; should not be null
+	 * @param callback        optional callback to be invoked when the request is complete; receives handles
+	 *                        via {@link EdgeCallbackWithError#onComplete} and per-event errors via
+	 *                        {@link EdgeCallbackWithError#onError}. It may be invoked on a different thread.
+	 */
+	public static void sendEvent(
+		@NonNull final ExperienceEvent experienceEvent,
+		@Nullable final EdgeCallbackWithError callback
+	) {
+		sendEvent(experienceEvent, (EdgeCallback) callback);
+	}
+
+	/**
 	 * Gets the Edge Network location hint used in requests to the Adobe Experience Platform Edge Network.
 	 * The Edge Network location hint may be used when building the URL for Adobe Experience Platform Edge Network
 	 * requests to hint at the server cluster to use.

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
@@ -38,6 +38,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * <ul>
  *   <li>batching disabled (default) → window of 1, identical to current single-event behaviour.
  *   <li>batching enabled → window of {@code min(queue.count(), MAX_BATCH_SIZE)}.
+ *   <li>draining a batch that just got a 400 → window of 1 for exactly that many cycles, regardless
+ *       of config, via {@link #explodeRemaining}.
  * </ul>
  */
 class EdgeBatchingHitQueue extends HitQueuing {
@@ -49,6 +51,13 @@ class EdgeBatchingHitQueue extends HitQueuing {
 	private final AtomicBoolean suspended = new AtomicBoolean(true);
 	private final AtomicBoolean isTaskScheduled = new AtomicBoolean(false);
 	private final ScheduledExecutorService scheduledExecutorService;
+
+	// Entities still to be drained one at a time after a batch 400, forcing batchSize to 1 until it
+	// reaches 0. Only ever touched from runBatchCycle, which always runs on
+	// scheduledExecutorService's single thread — no synchronization needed. Not persisted: if the
+	// process restarts mid-drain, normal batch-sized peeking resumes and, if the same events still
+	// form a bad batch, processBatch reports a fresh explodeCount and draining picks back up.
+	private int explodeRemaining = 0;
 
 	EdgeBatchingHitQueue(final DataQueue queue, final EdgeHitProcessor processor) {
 		this(queue, processor, Executors.newSingleThreadScheduledExecutor());
@@ -127,70 +136,73 @@ class EdgeBatchingHitQueue extends HitQueuing {
 			return;
 		}
 
-		final int batchSize = getEffectiveBatchSize(head);
+		// While draining a previously-exploded batch, force a window of 1 regardless of config —
+		// re-forming the same batch before it's fully drained would just repeat the same 400.
+		final int batchSize = explodeRemaining > 0 ? 1 : getEffectiveBatchSize(head);
 		final List<DataEntity> entities = batchSize > 1 ? queue.peek(batchSize) : Collections.singletonList(head);
 
 		final BatchOutcome outcome = processor.processBatch(entities);
 
+		int removeCount = 0;
+		int retryDelaySeconds = 0;
+
 		switch (outcome.getKind()) {
 			case DONE:
 				// Remove only what processBatch actually resolved — it may have been given a larger
-				// peeked window than it acted on (truncation at a Consent/Reset/decode-failure
-				// boundary, or a single non-ExperienceEvent head processed alone), and anything beyond
-				// the resolved prefix was never sent, so it must stay queued for the next cycle.
-				final int doneResolvedCount = outcome.getResolvedHeadCount();
-				if (doneResolvedCount > 0) {
-					queue.remove(doneResolvedCount);
+				// peeked window than it acted on (truncation at a Consent/Reset/decode-failure/
+				// allowlist/config boundary, or a single non-batchable head processed alone).
+				// Anything beyond the resolved prefix was never sent and stays queued for the next
+				// cycle.
+				removeCount = outcome.getValue();
+				if (explodeRemaining > 0) {
+					// One of the entities being drained resolved (delivered, dropped, or terminal
+					// error) — same completion criteria a genuinely single, non-batched event
+					// already uses.
+					explodeRemaining--;
 				}
-				isTaskScheduled.set(false);
-				processNextBatch();
 				break;
 
-			case RETRY_BATCH:
+			case RETRY:
+				// Nothing removed — a recoverable failure is retried in place, never skipped,
+				// whether or not this is mid-drain.
+				retryDelaySeconds = outcome.getValue();
+				break;
+
+			case EXPLODE:
+				explodeRemaining = outcome.getValue();
 				Log.trace(
 					LOG_TAG,
 					LOG_SOURCE,
-					"Batch of %d will be retried in %d seconds.",
-					entities.size(),
-					outcome.getRetryAfterSeconds()
-				);
-				scheduledExecutorService.schedule(
-					() -> {
-						isTaskScheduled.set(false);
-						processNextBatch();
-					},
-					outcome.getRetryAfterSeconds(),
-					TimeUnit.SECONDS
+					"Batch of %d events received 400; draining individually over the next %d cycle(s).",
+					explodeRemaining,
+					explodeRemaining
 				);
 				break;
+		}
 
-			case PARTIAL_REMOVE:
-				final int resolved = outcome.getResolvedHeadCount();
-				if (resolved > 0) {
-					queue.remove(resolved);
-				}
-				final int partialDelay = outcome.getRetryAfterSeconds();
-				if (partialDelay > 0) {
-					Log.trace(
-						LOG_TAG,
-						LOG_SOURCE,
-						"Partial removal of %d entities; next entity needs retry in %d seconds.",
-						resolved,
-						partialDelay
-					);
-					scheduledExecutorService.schedule(
-						() -> {
-							isTaskScheduled.set(false);
-							processNextBatch();
-						},
-						partialDelay,
-						TimeUnit.SECONDS
-					);
-				} else {
+		if (removeCount > 0) {
+			queue.remove(removeCount);
+		}
+
+		if (retryDelaySeconds > 0) {
+			Log.trace(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Removed %d resolved entities; next cycle scheduled in %d seconds.",
+				removeCount,
+				retryDelaySeconds
+			);
+			scheduledExecutorService.schedule(
+				() -> {
 					isTaskScheduled.set(false);
 					processNextBatch();
-				}
-				break;
+				},
+				retryDelaySeconds,
+				TimeUnit.SECONDS
+			);
+		} else {
+			isTaskScheduled.set(false);
+			processNextBatch();
 		}
 	}
 

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
@@ -161,13 +161,11 @@ class EdgeBatchingHitQueue extends HitQueuing {
 					explodeRemaining--;
 				}
 				break;
-
 			case RETRY:
 				// Nothing removed — a recoverable failure is retried in place, never skipped,
 				// whether or not this is mid-drain.
 				retryDelaySeconds = outcome.getValue();
 				break;
-
 			case EXPLODE:
 				explodeRemaining = outcome.getValue();
 				Log.trace(

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
@@ -71,14 +71,6 @@ class EdgeBatchingHitQueue extends HitQueuing {
 	@Override
 	public boolean queue(final DataEntity entity) {
 		final boolean result = queue.add(entity);
-		Log.debug(
-			LOG_TAG,
-			LOG_SOURCE,
-			"Queued entity %s (added=%b); queue depth now %d.",
-			entity != null ? entity.getUniqueIdentifier() : "null",
-			result,
-			queue.count()
-		);
 		processNextBatch();
 		return result;
 	}
@@ -142,7 +134,14 @@ class EdgeBatchingHitQueue extends HitQueuing {
 
 		switch (outcome.getKind()) {
 			case DONE:
-				queue.remove(entities.size());
+				// Remove only what processBatch actually resolved — it may have been given a larger
+				// peeked window than it acted on (truncation at a Consent/Reset/decode-failure
+				// boundary, or a single non-ExperienceEvent head processed alone), and anything beyond
+				// the resolved prefix was never sent, so it must stay queued for the next cycle.
+				final int doneResolvedCount = outcome.getResolvedHeadCount();
+				if (doneResolvedCount > 0) {
+					queue.remove(doneResolvedCount);
+				}
 				isTaskScheduled.set(false);
 				processNextBatch();
 				break;
@@ -211,14 +210,6 @@ class EdgeBatchingHitQueue extends HitQueuing {
 		);
 		final int queueDepth = queue.count();
 		final int batchSize = batchingEnabled ? Math.min(queueDepth, EdgeConstants.Defaults.MAX_BATCH_SIZE) : 1;
-		Log.debug(
-			LOG_TAG,
-			LOG_SOURCE,
-			"Batch-size decision: batching=%b, queueDepth=%d → batchSize=%d.",
-			batchingEnabled,
-			queueDepth,
-			batchSize
-		);
 		return batchSize;
 	}
 }

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Adobe. All rights reserved.
+  Copyright 2026 Adobe. All rights reserved.
   This file is licensed to you under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License. You may obtain a copy
   of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
@@ -1,0 +1,224 @@
+/*
+  Copyright 2019 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile;
+
+import static com.adobe.marketing.mobile.EdgeConstants.LOG_TAG;
+
+import androidx.annotation.VisibleForTesting;
+import com.adobe.marketing.mobile.services.DataEntity;
+import com.adobe.marketing.mobile.services.DataQueue;
+import com.adobe.marketing.mobile.services.HitQueuing;
+import com.adobe.marketing.mobile.services.Log;
+import com.adobe.marketing.mobile.util.DataReader;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Batch-capable hit queue for the Edge extension.
+ *
+ * <p>Uses the same {@link DataQueue} persistence and {@link ScheduledExecutorService} pattern as
+ * {@link com.adobe.marketing.mobile.services.PersistentHitQueue}, but processes a window of
+ * entities per cycle when batching is enabled ({@code edge.batching.enabled = true}).
+ *
+ * <p>The effective batch size is determined at processing time from the head entity's snapshotted
+ * configuration:
+ * <ul>
+ *   <li>batching disabled (default) → window of 1, identical to current single-event behaviour.
+ *   <li>batching enabled → window of {@code min(queue.count(), MAX_BATCH_SIZE)}.
+ * </ul>
+ */
+class EdgeBatchingHitQueue extends HitQueuing {
+
+	private static final String LOG_SOURCE = "EdgeBatchingHitQueue";
+
+	private final DataQueue queue;
+	private final EdgeHitProcessor processor;
+	private final AtomicBoolean suspended = new AtomicBoolean(true);
+	private final AtomicBoolean isTaskScheduled = new AtomicBoolean(false);
+	private final ScheduledExecutorService scheduledExecutorService;
+
+	EdgeBatchingHitQueue(final DataQueue queue, final EdgeHitProcessor processor) {
+		this(queue, processor, Executors.newSingleThreadScheduledExecutor());
+	}
+
+	@VisibleForTesting
+	EdgeBatchingHitQueue(
+		final DataQueue queue,
+		final EdgeHitProcessor processor,
+		final ScheduledExecutorService executorService
+	) {
+		if (queue == null || processor == null) {
+			throw new IllegalArgumentException("Null value is not allowed in EdgeBatchingHitQueue constructor.");
+		}
+		this.queue = queue;
+		this.processor = processor;
+		this.scheduledExecutorService = executorService;
+	}
+
+	@Override
+	public boolean queue(final DataEntity entity) {
+		final boolean result = queue.add(entity);
+		Log.debug(
+			LOG_TAG,
+			LOG_SOURCE,
+			"Queued entity %s (added=%b); queue depth now %d.",
+			entity != null ? entity.getUniqueIdentifier() : "null",
+			result,
+			queue.count()
+		);
+		processNextBatch();
+		return result;
+	}
+
+	@Override
+	public void beginProcessing() {
+		suspended.set(false);
+		processNextBatch();
+	}
+
+	@Override
+	public void suspend() {
+		suspended.set(true);
+	}
+
+	@Override
+	public void clear() {
+		queue.clear();
+	}
+
+	@Override
+	public int count() {
+		return queue.count();
+	}
+
+	@Override
+	public void close() {
+		suspend();
+		queue.close();
+		scheduledExecutorService.shutdown();
+	}
+
+	/**
+	 * Schedules one batch-processing cycle if none is already running.
+	 * Mirrors the guard in {@code PersistentHitQueue.processNextHit()}.
+	 */
+	private void processNextBatch() {
+		if (suspended.get()) {
+			return;
+		}
+
+		if (!isTaskScheduled.compareAndSet(false, true)) {
+			return;
+		}
+
+		scheduledExecutorService.execute(this::runBatchCycle);
+	}
+
+	private void runBatchCycle() {
+		// Peek head to determine effective batch size from snapshotted config.
+		final DataEntity head = queue.peek();
+		if (head == null) {
+			isTaskScheduled.set(false);
+			return;
+		}
+
+		final int batchSize = getEffectiveBatchSize(head);
+		final List<DataEntity> entities = batchSize > 1 ? queue.peek(batchSize) : Collections.singletonList(head);
+
+		final BatchOutcome outcome = processor.processBatch(entities);
+
+		switch (outcome.getKind()) {
+			case DONE:
+				queue.remove(entities.size());
+				isTaskScheduled.set(false);
+				processNextBatch();
+				break;
+
+			case RETRY_BATCH:
+				Log.trace(
+					LOG_TAG,
+					LOG_SOURCE,
+					"Batch of %d will be retried in %d seconds.",
+					entities.size(),
+					outcome.getRetryAfterSeconds()
+				);
+				scheduledExecutorService.schedule(
+					() -> {
+						isTaskScheduled.set(false);
+						processNextBatch();
+					},
+					outcome.getRetryAfterSeconds(),
+					TimeUnit.SECONDS
+				);
+				break;
+
+			case PARTIAL_REMOVE:
+				final int resolved = outcome.getResolvedHeadCount();
+				if (resolved > 0) {
+					queue.remove(resolved);
+				}
+				final int partialDelay = outcome.getRetryAfterSeconds();
+				if (partialDelay > 0) {
+					Log.trace(
+						LOG_TAG,
+						LOG_SOURCE,
+						"Partial removal of %d entities; next entity needs retry in %d seconds.",
+						resolved,
+						partialDelay
+					);
+					scheduledExecutorService.schedule(
+						() -> {
+							isTaskScheduled.set(false);
+							processNextBatch();
+						},
+						partialDelay,
+						TimeUnit.SECONDS
+					);
+				} else {
+					isTaskScheduled.set(false);
+					processNextBatch();
+				}
+				break;
+		}
+	}
+
+	/**
+	 * Returns the number of entities to include in the next batch, based on the
+	 * {@code edge.batching.enabled} flag snapshotted in the head entity's configuration.
+	 */
+	private int getEffectiveBatchSize(final DataEntity head) {
+		final EdgeDataEntity entity = EdgeDataEntity.fromDataEntity(head);
+		if (entity == null) {
+			return 1;
+		}
+		final boolean batchingEnabled = DataReader.optBoolean(
+			entity.getConfiguration(),
+			EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED,
+			false
+		);
+		final int queueDepth = queue.count();
+		final int batchSize = batchingEnabled ? Math.min(queueDepth, EdgeConstants.Defaults.MAX_BATCH_SIZE) : 1;
+		Log.debug(
+			LOG_TAG,
+			LOG_SOURCE,
+			"Batch-size decision: batching=%b, queueDepth=%d → batchSize=%d.",
+			batchingEnabled,
+			queueDepth,
+			batchSize
+		);
+		return batchSize;
+	}
+}

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
@@ -223,7 +223,7 @@ class EdgeBatchingHitQueue extends HitQueuing {
 			false
 		);
 		final int queueDepth = queue.count();
-        return batchingEnabled ? Math.min(queueDepth, getMaxBatchSize(entity)) : 1;
+		return batchingEnabled ? Math.min(queueDepth, getMaxBatchSize(entity)) : 1;
 	}
 
 	/**

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBatchingHitQueue.java
@@ -37,7 +37,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * configuration:
  * <ul>
  *   <li>batching disabled (default) → window of 1, identical to current single-event behaviour.
- *   <li>batching enabled → window of {@code min(queue.count(), MAX_BATCH_SIZE)}.
+ *   <li>batching enabled → window of {@code min(queue.count(), maxBatchSize)}, where
+ *       {@code maxBatchSize} comes from {@code edge.batching.maxBatchSize} (falling back to
+ *       {@link EdgeConstants.Defaults#MAX_BATCH_SIZE} if absent or non-positive, and clamped to
+ *       {@link EdgeConstants.Defaults#MAX_BATCH_SIZE_LIMIT} regardless of source).
  *   <li>draining a batch that just got a 400 → window of 1 for exactly that many cycles, regardless
  *       of config, via {@link #explodeRemaining}.
  * </ul>
@@ -206,7 +209,8 @@ class EdgeBatchingHitQueue extends HitQueuing {
 
 	/**
 	 * Returns the number of entities to include in the next batch, based on the
-	 * {@code edge.batching.enabled} flag snapshotted in the head entity's configuration.
+	 * {@code edge.batching.enabled} flag and {@code edge.batching.maxBatchSize} snapshotted in the
+	 * head entity's configuration.
 	 */
 	private int getEffectiveBatchSize(final DataEntity head) {
 		final EdgeDataEntity entity = EdgeDataEntity.fromDataEntity(head);
@@ -219,7 +223,24 @@ class EdgeBatchingHitQueue extends HitQueuing {
 			false
 		);
 		final int queueDepth = queue.count();
-		final int batchSize = batchingEnabled ? Math.min(queueDepth, EdgeConstants.Defaults.MAX_BATCH_SIZE) : 1;
-		return batchSize;
+        return batchingEnabled ? Math.min(queueDepth, getMaxBatchSize(entity)) : 1;
+	}
+
+	/**
+	 * Returns the configured {@code edge.batching.maxBatchSize} from the entity's snapshotted
+	 * configuration, or {@link EdgeConstants.Defaults#MAX_BATCH_SIZE} if the key is absent or not a
+	 * positive value. Clamped to {@link EdgeConstants.Defaults#MAX_BATCH_SIZE_LIMIT} regardless of
+	 * source, so a misconfigured value can't grow the batch (and the request payload) unbounded.
+	 */
+	private int getMaxBatchSize(final EdgeDataEntity entity) {
+		final int configured = DataReader.optInt(
+			entity.getConfiguration(),
+			EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE,
+			EdgeConstants.Defaults.MAX_BATCH_SIZE
+		);
+		if (configured <= 0) {
+			return EdgeConstants.Defaults.MAX_BATCH_SIZE;
+		}
+		return Math.min(configured, EdgeConstants.Defaults.MAX_BATCH_SIZE_LIMIT);
 	}
 }

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBundledBatchingConfig.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBundledBatchingConfig.java
@@ -23,17 +23,18 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
- * Loads a first-launch fallback for the Edge batching configuration keys ({@code edge.batching.enabled}
- * and {@code edge.batching.eventNameAllowlist}) from a JSON file bundled in the app's assets folder.
+ * Loads a first-launch fallback for the Edge batching configuration keys ({@code edge.batching.enabled},
+ * {@code edge.batching.eventNameAllowlist}, and {@code edge.batching.maxBatchSize}) from a JSON file
+ * bundled in the app's assets folder.
  *
  * <p>This is a per-key fallback, not a wholesale configuration replacement: {@link EventUtils#getEdgeConfiguration}
- * consults this bundled file only for whichever of the two batching keys is absent from the Configuration
+ * consults this bundled file only for whichever batching key is absent from the Configuration
  * shared state at the time an event is queued. Any key present in the Configuration shared state — whether
  * set programmatically via {@code MobileCore.updateConfiguration()} or delivered by a remote/Launch-published
  * configuration — always takes precedence over the bundled file's value for that same key.
  *
  * <p>Unlike Mobile Core's own {@code ADBMobileConfig.json} bundled-configuration mechanism (which this
- * mirrors in spirit), this file is scoped specifically to the two Edge batching keys and is not a
+ * mirrors in spirit), this file is scoped specifically to the Edge batching keys and is not a
  * general-purpose configuration bundle.
  */
 final class EdgeBundledBatchingConfig {

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBundledBatchingConfig.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBundledBatchingConfig.java
@@ -1,0 +1,126 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile;
+
+import androidx.annotation.VisibleForTesting;
+import com.adobe.marketing.mobile.services.Log;
+import com.adobe.marketing.mobile.services.ServiceProvider;
+import com.adobe.marketing.mobile.util.JSONUtils;
+import com.adobe.marketing.mobile.util.StreamUtils;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Loads a first-launch fallback for the Edge batching configuration keys ({@code edge.batching.enabled}
+ * and {@code edge.batching.eventNameAllowlist}) from a JSON file bundled in the app's assets folder.
+ *
+ * <p>This is a per-key fallback, not a wholesale configuration replacement: {@link EventUtils#getEdgeConfiguration}
+ * consults this bundled file only for whichever of the two batching keys is absent from the Configuration
+ * shared state at the time an event is queued. Any key present in the Configuration shared state — whether
+ * set programmatically via {@code MobileCore.updateConfiguration()} or delivered by a remote/Launch-published
+ * configuration — always takes precedence over the bundled file's value for that same key.
+ *
+ * <p>Unlike Mobile Core's own {@code ADBMobileConfig.json} bundled-configuration mechanism (which this
+ * mirrors in spirit), this file is scoped specifically to the two Edge batching keys and is not a
+ * general-purpose configuration bundle.
+ */
+final class EdgeBundledBatchingConfig {
+
+	private static final String LOG_SOURCE = "EdgeBundledBatchingConfig";
+
+	/** Name of the JSON file expected in the app's assets folder. */
+	static final String BUNDLED_CONFIG_FILE_NAME = "adb_edgeBatchingConfig.json";
+
+	private static final Object loadLock = new Object();
+	private static volatile Map<String, Object> cachedConfig;
+	private static volatile boolean loadAttempted = false;
+
+	private EdgeBundledBatchingConfig() {}
+
+	/**
+	 * Returns the parsed contents of the bundled batching config file, loading and caching it the
+	 * first time this is called. Subsequent calls return the cached result without re-reading the
+	 * file. Returns an empty map (never null) if the file is missing, empty, or malformed.
+	 *
+	 * @return a read-only {@code Map} of whatever keys the bundled file contains
+	 */
+	static Map<String, Object> get() {
+		if (!loadAttempted) {
+			synchronized (loadLock) {
+				if (!loadAttempted) {
+					cachedConfig = load();
+					loadAttempted = true;
+				}
+			}
+		}
+
+		return cachedConfig;
+	}
+
+	/**
+	 * Clears the cached result so the next call to {@link #get()} re-reads the bundled file.
+	 * Test-only; production code should never need to force a re-read.
+	 */
+	@VisibleForTesting
+	static void resetForTesting() {
+		synchronized (loadLock) {
+			cachedConfig = null;
+			loadAttempted = false;
+		}
+	}
+
+	private static Map<String, Object> load() {
+		final InputStream inputStream = ServiceProvider
+			.getInstance()
+			.getDeviceInfoService()
+			.getAsset(BUNDLED_CONFIG_FILE_NAME);
+		final String content = StreamUtils.readAsString(inputStream);
+
+		if (content == null || content.isEmpty()) {
+			Log.trace(
+				EdgeConstants.LOG_TAG,
+				LOG_SOURCE,
+				"No bundled batching config file '%s' found in assets; skipping.",
+				BUNDLED_CONFIG_FILE_NAME
+			);
+			return Collections.emptyMap();
+		}
+
+		try {
+			final Map<String, Object> parsed = JSONUtils.toMap(new JSONObject(content));
+			if (parsed == null) {
+				return Collections.emptyMap();
+			}
+
+			Log.debug(
+				EdgeConstants.LOG_TAG,
+				LOG_SOURCE,
+				"Loaded bundled batching config from '%s': %s",
+				BUNDLED_CONFIG_FILE_NAME,
+				parsed
+			);
+			return parsed;
+		} catch (final JSONException e) {
+			Log.warning(
+				EdgeConstants.LOG_TAG,
+				LOG_SOURCE,
+				"Failed to parse bundled batching config file '%s': %s",
+				BUNDLED_CONFIG_FILE_NAME,
+				e.getLocalizedMessage()
+			);
+			return Collections.emptyMap();
+		}
+	}
+}

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBundledBatchingConfig.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeBundledBatchingConfig.java
@@ -42,7 +42,7 @@ final class EdgeBundledBatchingConfig {
 	private static final String LOG_SOURCE = "EdgeBundledBatchingConfig";
 
 	/** Name of the JSON file expected in the app's assets folder. */
-	static final String BUNDLED_CONFIG_FILE_NAME = "adb_edgeBatchingConfig.json";
+	static final String BUNDLED_CONFIG_FILE_NAME = "ADBMobilEdgeBatchingConfig.json";
 
 	private static final Object loadLock = new Object();
 	private static volatile Map<String, Object> cachedConfig;

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeCallbackWithError.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeCallbackWithError.java
@@ -1,0 +1,34 @@
+/*
+  Copyright 2019 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile;
+
+import java.util.List;
+
+/**
+ * Extended callback interface for {@code Edge.sendEvent} callers that want to receive both
+ * success handles and per-event errors in a single callback object.
+ *
+ * <p>Implementors of this interface can pass an instance to either
+ * {@link Edge#sendEvent(ExperienceEvent, EdgeCallback)} or
+ * {@link Edge#sendEvent(ExperienceEvent, EdgeCallbackWithError)}. In both cases the SDK checks
+ * for this interface at dispatch time and calls {@link #onError} when errors are available.
+ */
+public interface EdgeCallbackWithError extends EdgeCallback {
+
+	/**
+	 * Called when one or more errors are returned for the sent {@link ExperienceEvent}.
+	 * May be called alongside {@link #onComplete} if some handles were also returned.
+	 *
+	 * @param errors list of errors returned by the Adobe Experience Edge; never null, never empty
+	 */
+	void onError(final List<EdgeEventError> errors);
+}

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeCallbackWithError.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeCallbackWithError.java
@@ -23,7 +23,6 @@ import java.util.List;
  * for this interface at dispatch time and calls {@link #onError} when errors are available.
  */
 public interface EdgeCallbackWithError extends EdgeCallback {
-
 	/**
 	 * Called when one or more errors are returned for the sent {@link ExperienceEvent}.
 	 * May be called alongside {@link #onComplete} if some handles were also returned.

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeCallbackWithError.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeCallbackWithError.java
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Adobe. All rights reserved.
+  Copyright 2026 Adobe. All rights reserved.
   This file is licensed to you under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License. You may obtain a copy
   of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
@@ -14,7 +14,7 @@ package com.adobe.marketing.mobile;
 final class EdgeConstants {
 
 	static final String EDGE_DATA_STORAGE = "EdgeDataStorage";
-	static final String EXTENSION_VERSION = "3.0.2";
+	static final String EXTENSION_VERSION = "3.1.2";
 	static final String EXTENSION_NAME = "com.adobe.edge";
 	static final String FRIENDLY_NAME = "Edge";
 	static final String LOG_TAG = FRIENDLY_NAME;

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
@@ -108,6 +108,7 @@ final class EdgeConstants {
 			static final String EDGE_DOMAIN = "edge.domain";
 			static final String EDGE_REQUEST_ENVIRONMENT = "edge.environment";
 			static final String EDGE_BATCHING_ENABLED = "edge.batching.enabled";
+			static final String EDGE_BATCHING_EVENT_NAME_ALLOWLIST = "edge.batching.eventNameAllowlist";
 
 			private Configuration() {}
 		}

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
@@ -39,7 +39,11 @@ final class EdgeConstants {
 		static final String REQUEST_CONFIG_LINE_FEED = "\n";
 		static final int RETRY_INTERVAL_SECONDS = 5;
 		static final int LOCATION_HINT_TTL_SEC = 1800;
+		// Fallback used when edge.batching.maxBatchSize is absent from both Configuration and the
+		// bundled batching config file, or is not a positive value.
 		static final int MAX_BATCH_SIZE = 10;
+		// Upper bound a configured edge.batching.maxBatchSize is clamped to, regardless of source.
+		static final int MAX_BATCH_SIZE_LIMIT = 20;
 
 		static final ConsentStatus COLLECT_CONSENT_YES = ConsentStatus.YES; // used if Consent extension is not registered
 		static final ConsentStatus COLLECT_CONSENT_PENDING = ConsentStatus.PENDING; // used when Consent encoding failed or the value different than y/n
@@ -109,6 +113,7 @@ final class EdgeConstants {
 			static final String EDGE_REQUEST_ENVIRONMENT = "edge.environment";
 			static final String EDGE_BATCHING_ENABLED = "edge.batching.enabled";
 			static final String EDGE_BATCHING_EVENT_NAME_ALLOWLIST = "edge.batching.eventNameAllowlist";
+			static final String EDGE_BATCHING_MAX_BATCH_SIZE = "edge.batching.maxBatchSize";
 
 			private Configuration() {}
 		}

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeConstants.java
@@ -39,6 +39,7 @@ final class EdgeConstants {
 		static final String REQUEST_CONFIG_LINE_FEED = "\n";
 		static final int RETRY_INTERVAL_SECONDS = 5;
 		static final int LOCATION_HINT_TTL_SEC = 1800;
+		static final int MAX_BATCH_SIZE = 10;
 
 		static final ConsentStatus COLLECT_CONSENT_YES = ConsentStatus.YES; // used if Consent extension is not registered
 		static final ConsentStatus COLLECT_CONSENT_PENDING = ConsentStatus.PENDING; // used when Consent encoding failed or the value different than y/n
@@ -106,6 +107,7 @@ final class EdgeConstants {
 			static final String EDGE_CONFIG_ID = "edge.configId";
 			static final String EDGE_DOMAIN = "edge.domain";
 			static final String EDGE_REQUEST_ENVIRONMENT = "edge.environment";
+			static final String EDGE_BATCHING_ENABLED = "edge.batching.enabled";
 
 			private Configuration() {}
 		}

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeEventError.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeEventError.java
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Adobe. All rights reserved.
+  Copyright 2026 Adobe. All rights reserved.
   This file is licensed to you under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License. You may obtain a copy
   of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeEventError.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeEventError.java
@@ -1,0 +1,56 @@
+/*
+  Copyright 2019 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile;
+
+/**
+ * Represents a per-event error returned by the Adobe Experience Edge Network for a batched
+ * {@link ExperienceEvent}. Delivered via {@link EdgeCallbackWithError#onError}.
+ */
+public class EdgeEventError {
+
+	private final String type;
+	private final int status;
+	private final String title;
+	private final String detail;
+
+	EdgeEventError(final String type, final int status, final String title, final String detail) {
+		this.type = type;
+		this.status = status;
+		this.title = title;
+		this.detail = detail;
+	}
+
+	/** @return the error type URI (e.g. {@code "https://ns.adobe.com/aep/errors/EXEG-0203-502"}) */
+	public String getType() {
+		return type;
+	}
+
+	/** @return the HTTP-like status code embedded in the error */
+	public int getStatus() {
+		return status;
+	}
+
+	/** @return short human-readable error title */
+	public String getTitle() {
+		return title;
+	}
+
+	/** @return detailed error description, or null if not present */
+	public String getDetail() {
+		return detail;
+	}
+
+	@Override
+	public String toString() {
+		return "EdgeEventError{type='" + type + "', status=" + status + ", title='" + title + "'}";
+	}
+}

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeEventHandle.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeEventHandle.java
@@ -23,6 +23,8 @@ import org.json.JSONObject;
  */
 public class EdgeEventHandle {
 
+	static final int ABSENT_EVENT_INDEX = -1;
+
 	private final int eventIndex;
 	private final String type;
 	private final List<Map<String, Object>> payload;
@@ -41,7 +43,7 @@ public class EdgeEventHandle {
 
 		String tempType = handle.optString(EdgeJson.Response.EventHandle.TYPE);
 		this.type = StringUtils.isNullOrEmpty(tempType) ? null : tempType;
-		this.eventIndex = handle.optInt(EdgeJson.Response.EventHandle.EVENT_INDEX, 0);
+		this.eventIndex = handle.optInt(EdgeJson.Response.EventHandle.EVENT_INDEX, ABSENT_EVENT_INDEX);
 		this.payload = Utils.toListOfMaps(handle.optJSONArray(EdgeJson.Response.EventHandle.PAYLOAD));
 	}
 
@@ -60,8 +62,8 @@ public class EdgeEventHandle {
 	}
 
 	/**
-	 * @return Encodes the event to which this handle is attached as the index in the events array in EdgeRequest
-	 * If not found in the {@link JSONObject} response, it fallbacks to 0 as per Edge Network spec
+	 * @return the index of the event in the batch this handle is attached to, or
+	 * {@link #ABSENT_EVENT_INDEX} if no eventIndex was present in the response (global handle).
 	 */
 	int getEventIndex() {
 		return eventIndex;

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeExtension.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeExtension.java
@@ -19,7 +19,6 @@ import com.adobe.marketing.mobile.services.DataQueue;
 import com.adobe.marketing.mobile.services.HitQueuing;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.NamedCollection;
-import com.adobe.marketing.mobile.services.PersistentHitQueue;
 import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DataReaderException;

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeExtension.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeExtension.java
@@ -98,7 +98,7 @@ class EdgeExtension extends Extension {
 			);
 
 			final DataQueue dataQueue = ServiceProvider.getInstance().getDataQueueService().getDataQueue(getName());
-			this.hitQueue = new PersistentHitQueue(dataQueue, hitProcessor);
+			this.hitQueue = new EdgeBatchingHitQueue(dataQueue, hitProcessor);
 		} else {
 			this.hitQueue = hitQueue;
 		}

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
@@ -88,7 +88,7 @@ class EdgeHitProcessor implements HitProcessing {
 	 * @return {@link BatchOutcome} instructing the queue how to advance
 	 */
 	BatchOutcome processBatch(@NonNull final List<DataEntity> entities) {
-		if(entities.isEmpty()) return BatchOutcome.done();
+		if(entities.isEmpty()) return BatchOutcome.done(0);
 
 		final DataEntity headEntity = entities.get(0);
 		final EdgeDataEntity headEdgeEntity = EdgeDataEntity.fromDataEntity(headEntity);
@@ -96,7 +96,7 @@ class EdgeHitProcessor implements HitProcessing {
 		if (headEdgeEntity == null) {
 			Log.debug(LOG_TAG, LOG_SOURCE,
 					"Unable to deserialize head entity to EdgeDataEntity, dropping.");
-			return BatchOutcome.done();
+			return BatchOutcome.done(1);
 		}
 
 		// Non-experience events (consent, reset) must be processed alone.
@@ -145,14 +145,14 @@ class EdgeHitProcessor implements HitProcessing {
 			Log.debug(LOG_TAG, LOG_SOURCE,
 					"Cannot process batch: Edge config ID is null/empty, dropping %d events.",
 					batchEntities.size());
-			return BatchOutcome.done();
+			return BatchOutcome.done(batchEntities.size());
 		}
 
 		final JSONObject requestPayload = request.getPayloadWithExperienceEvents(batchEvents);
 		if (requestPayload == null) {
 			Log.warning(LOG_TAG, LOG_SOURCE,
 					"Failed to build batch request payload, dropping %d events.", batchEntities.size());
-			return BatchOutcome.done();
+			return BatchOutcome.done(batchEntities.size());
 		}
 
 		final Map<String, Object> requestProperties = getRequestProperties(headEdgeEntity.getEvent());
@@ -164,22 +164,14 @@ class EdgeHitProcessor implements HitProcessing {
 		networkResponseHandler.addWaitingEvents(edgeHit.getRequestId(), batchEvents);
 
 		final Map<String, String> requestHeaders = getRequestHeaders();
-		// Measure the full request round trip (connect + response read + onComplete) — doRequest is
-		// synchronous, so this spans send → response received for this request id.
-		final long startNanos = System.nanoTime();
 		final RetryResult result = sendBatchNetworkRequest(
 				headEntity.getUniqueIdentifier(), edgeHit, requestHeaders);
-		final long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
-		Log.debug(LOG_TAG, LOG_SOURCE,
-				"Round trip for request id (%s) with %d event(s): %d ms (outcome=%s).",
-				edgeHit.getRequestId(), batchEntities.size(), elapsedMs,
-				result.getNetworkRequestOutcome());
 
 		switch (result.getNetworkRequestOutcome()) {
 			case SUCCESS:
 				Log.debug(LOG_TAG, LOG_SOURCE,
 						"Batch of %d events sent and processed successfully.", batchEntities.size());
-				return BatchOutcome.done();
+				return BatchOutcome.done(batchEntities.size());
 
 			case RETRY:
 				Log.debug(LOG_TAG, LOG_SOURCE,
@@ -194,7 +186,7 @@ class EdgeHitProcessor implements HitProcessing {
 							"Single event received 400; delivering terminal error for request id (%s).",
 							edgeHit.getRequestId());
 					deliverTerminalBadRequest(edgeHit.getRequestId(), result.getResponseBody());
-					return BatchOutcome.done();
+					return BatchOutcome.done(1);
 				} else {
 					// Batch of N>1: nothing ingested — clean up waiting state then explode.
 					Log.warning(LOG_TAG, LOG_SOURCE,
@@ -208,10 +200,10 @@ class EdgeHitProcessor implements HitProcessing {
 				Log.warning(LOG_TAG, LOG_SOURCE,
 						"Batch of %d events received non-recoverable error; dropping all.",
 						batchEntities.size());
-				return BatchOutcome.done();
+				return BatchOutcome.done(batchEntities.size());
 
 			default:
-				return BatchOutcome.done();
+				return BatchOutcome.done(batchEntities.size());
 		}
 	}
 
@@ -223,7 +215,7 @@ class EdgeHitProcessor implements HitProcessing {
 		final boolean[] done = { true };
 		processHit(entity, result -> done[0] = result);
 		if (done[0]) {
-			return BatchOutcome.done();
+			return BatchOutcome.done(1);
 		}
 		return BatchOutcome.retryBatch(retryInterval(entity));
 	}
@@ -359,7 +351,7 @@ class EdgeHitProcessor implements HitProcessing {
 
 		Log.debug(LOG_TAG, LOG_SOURCE,
 				"Explosion complete: all %d events resolved.", batchEntities.size());
-		return BatchOutcome.done();
+		return BatchOutcome.done(resolvedCount);
 	}
 
 	/**

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
@@ -26,10 +26,10 @@ import com.adobe.marketing.mobile.util.MapUtils;
 import com.adobe.marketing.mobile.util.StringUtils;
 import com.adobe.marketing.mobile.util.UrlUtils;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -78,44 +78,34 @@ class EdgeHitProcessor implements HitProcessing {
 	 *
 	 * <p>Routing rules:
 	 * <ul>
-	 *   <li>Head is not an ExperienceEvent → process head alone (consent, reset, etc.).</li>
-	 *   <li>Batch size == 1 OR only head qualifies → single-entity path.</li>
-	 *   <li>Multiple consecutive ExperienceEvents → build a batch request; on 400, explode to
-	 *       individual sends; on other non-recoverable, drop all and error.</li>
+	 *   <li>Head is not a batchable ExperienceEvent (wrong type, not allowlisted), or only the head
+	 *       qualifies → single-entity path.</li>
+	 *   <li>Multiple consecutive batchable ExperienceEvents that also share the head's snapshotted
+	 *       config → build one batch request; on 400, drain individually; on other non-recoverable,
+	 *       drop all and error.</li>
 	 * </ul>
 	 *
 	 * @param entities ordered list of entities to process; never null, never empty
 	 * @return {@link BatchOutcome} instructing the queue how to advance
 	 */
 	BatchOutcome processBatch(@NonNull final List<DataEntity> entities) {
-		if(entities.isEmpty()) return BatchOutcome.done(0);
+		if (entities.isEmpty()) {
+			return BatchOutcome.done(0);
+		}
 
 		final DataEntity headEntity = entities.get(0);
 		final EdgeDataEntity headEdgeEntity = EdgeDataEntity.fromDataEntity(headEntity);
 
 		if (headEdgeEntity == null) {
-			Log.debug(LOG_TAG, LOG_SOURCE,
-					"Unable to deserialize head entity to EdgeDataEntity, dropping.");
+			Log.debug(LOG_TAG, LOG_SOURCE, "Unable to deserialize head entity to EdgeDataEntity, dropping.");
 			return BatchOutcome.done(1);
 		}
 
-		// Non-experience events (consent, reset) must be processed alone.
-		if (!EventUtils.isExperienceEvent(headEdgeEntity.getEvent())) {
-			Log.trace(LOG_TAG, LOG_SOURCE,
-					"Head entity is not an ExperienceEvent (%s); processing alone.",
-					headEdgeEntity.getEvent().getType());
-			return processSingleEntity(headEntity);
-		}
-
-		// Events whose name isn't in the configured allowlist must also be processed alone.
-		if (!isEventNameAllowlistedForBatching(headEdgeEntity)) {
-			Log.trace(LOG_TAG, LOG_SOURCE,
-					"Head entity's event name (%s) is not in the batching allowlist; processing alone.",
-					headEdgeEntity.getEvent().getName());
-			return processSingleEntity(headEntity);
-		}
-
-		// Collect the consecutive ExperienceEvent run from the front.
+		// Collect the consecutive run of batchable ExperienceEvents from the front. An entity is
+		// batchable only if it decodes, is an ExperienceEvent, is on the event-name allowlist, and
+		// shares the head's snapshotted config (a single request can only carry one datastream
+		// ID/override, so events queued under a different config cannot be combined with the head's).
+		// The first entity that fails any of these (including the head) stops the run.
 		final List<DataEntity> batchEntities = new ArrayList<>();
 		final List<Event> batchEvents = new ArrayList<>();
 
@@ -124,7 +114,8 @@ class EdgeHitProcessor implements HitProcessing {
 			if (
 				edgeEntity == null ||
 				!EventUtils.isExperienceEvent(edgeEntity.getEvent()) ||
-				!isEventNameAllowlistedForBatching(edgeEntity)
+				!isEventNameAllowlistedForBatching(edgeEntity) ||
+				!hasSameRequestConfig(edgeEntity, headEdgeEntity)
 			) {
 				break;
 			}
@@ -132,52 +123,28 @@ class EdgeHitProcessor implements HitProcessing {
 			batchEvents.add(edgeEntity.getEvent());
 		}
 
-		Log.debug(LOG_TAG, LOG_SOURCE,
-				"Processing batch of %d ExperienceEvent(s).", batchEntities.size());
-
-		// Build batch request using the head entity's snapshotted configuration.
-		final RequestBuilder request = new RequestBuilder(namedCollection);
-		request.addXdmPayload(headEdgeEntity.getIdentityMap());
-		request.enableResponseStreaming(
-				EdgeConstants.Defaults.REQUEST_CONFIG_RECORD_SEPARATOR,
-				EdgeConstants.Defaults.REQUEST_CONFIG_LINE_FEED
-		);
-
-		if (stateCallback != null) {
-			request.addXdmPayload(stateCallback.getImplementationDetails());
+		// Head isn't batchable (non-ExperienceEvent, or not allowlisted), or only the head qualifies —
+		// process the head alone via the existing single-entity path (consent, reset, non-allowlisted,
+		// and single-Experience-event cases all funnel here).
+		if (batchEntities.size() <= 1) {
+			Log.trace(LOG_TAG, LOG_SOURCE,
+					"Head entity (%s) is not batchable or is the only batchable entity; processing alone.",
+					headEdgeEntity.getEvent().getName());
+			return processSingleEntity(headEntity);
 		}
 
-		final Map<String, Object> edgeConfig = headEdgeEntity.getConfiguration();
-		String datastreamId = DataReader.optString(
-				edgeConfig, EdgeConstants.SharedState.Configuration.EDGE_CONFIG_ID, null);
-		final Map<String, Object> headEventConfigMap = EventUtils.getConfig(headEdgeEntity.getEvent());
-		datastreamId = processEventConfigOverrides(headEventConfigMap, request, datastreamId);
+		Log.debug(LOG_TAG, LOG_SOURCE, "Processing batch of %d ExperienceEvent(s).", batchEntities.size());
 
-		if (StringUtils.isNullOrEmpty(datastreamId)) {
-			Log.debug(LOG_TAG, LOG_SOURCE,
-					"Cannot process batch: Edge config ID is null/empty, dropping %d events.",
-					batchEntities.size());
+		final EdgeHit edgeHit = buildExperienceEventHit(headEdgeEntity, batchEvents);
+		if (edgeHit == null) {
+			// Config ID missing/empty or payload build failed — drop the whole batch.
 			return BatchOutcome.done(batchEntities.size());
 		}
-
-		final JSONObject requestPayload = request.getPayloadWithExperienceEvents(batchEvents);
-		if (requestPayload == null) {
-			Log.warning(LOG_TAG, LOG_SOURCE,
-					"Failed to build batch request payload, dropping %d events.", batchEntities.size());
-			return BatchOutcome.done(batchEntities.size());
-		}
-
-		final Map<String, Object> requestProperties = getRequestProperties(headEdgeEntity.getEvent());
-		final EdgeEndpoint edgeEndpoint = getEdgeEndpoint(
-				EdgeNetworkService.RequestType.INTERACT, edgeConfig, requestProperties);
-		final EdgeHit edgeHit = new EdgeHit(datastreamId, requestPayload, edgeEndpoint);
 
 		// Register all events before the network call so response fragments can be routed.
 		networkResponseHandler.addWaitingEvents(edgeHit.getRequestId(), batchEvents);
 
-		final Map<String, String> requestHeaders = getRequestHeaders();
-		final RetryResult result = sendBatchNetworkRequest(
-				headEntity.getUniqueIdentifier(), edgeHit, requestHeaders);
+		final RetryResult result = sendEdgeHit(headEntity.getUniqueIdentifier(), edgeHit, getRequestHeaders(), true);
 
 		switch (result.getNetworkRequestOutcome()) {
 			case SUCCESS:
@@ -192,29 +159,20 @@ class EdgeHitProcessor implements HitProcessing {
 				return BatchOutcome.retryBatch(result.getRetryIntervalSeconds());
 
 			case EXPLODE_400:
-				if (batchEntities.size() == 1) {
-					// Terminal: single event got a 400 — deliver the real error and fire completion.
-					Log.warning(LOG_TAG, LOG_SOURCE,
-							"Single event received 400; delivering terminal error for request id (%s).",
-							edgeHit.getRequestId());
-					deliverTerminalBadRequest(edgeHit.getRequestId(), result.getResponseBody());
-					return BatchOutcome.done(1);
-				} else {
-					// Batch of N>1: nothing ingested — clean up waiting state then explode.
-					Log.warning(LOG_TAG, LOG_SOURCE,
-							"Batch of %d events received 400; exploding to individual requests.",
-							batchEntities.size());
-					networkResponseHandler.removeWaitingEvents(edgeHit.getRequestId());
-					return explodeAndResend(batchEntities);
-				}
+				// Batch of N>1 nothing ingested — clean up waiting state and tell the queue to drain
+				// these entities one at a time via the ordinary single-event path (see
+				// EdgeBatchingHitQueue#runBatchCycle).
+				Log.warning(LOG_TAG, LOG_SOURCE,
+						"Batch of %d events received 400; draining individually.",
+						batchEntities.size());
+				networkResponseHandler.removeWaitingEvents(edgeHit.getRequestId());
+				return BatchOutcome.explode(batchEntities.size());
 
 			case DROP:
+			default:
 				Log.warning(LOG_TAG, LOG_SOURCE,
 						"Batch of %d events received non-recoverable error; dropping all.",
 						batchEntities.size());
-				return BatchOutcome.done(batchEntities.size());
-
-			default:
 				return BatchOutcome.done(batchEntities.size());
 		}
 	}
@@ -244,6 +202,27 @@ class EdgeHitProcessor implements HitProcessing {
 	}
 
 	/**
+	 * Checks whether {@code candidate} shares the same request-building config as {@code head}: the
+	 * snapshotted Configuration state (datastream ID, environment, domain, ...) and the event-level
+	 * overrides ({@code datastreamIdOverride}/{@code datastreamConfigOverride}). A batched request can
+	 * only carry one of each — built entirely from the head's config (see {@link
+	 * #buildExperienceEventHit}) — so an entity whose own snapshot differs from the head's must not be
+	 * folded into the same request; it would silently lose its own config and be sent under the head's.
+	 *
+	 * @param candidate the entity being considered for the batch run
+	 * @param head the entity the batch request will actually be built from
+	 * @return true if {@code candidate} may be safely combined with {@code head} in one request
+	 */
+	private boolean hasSameRequestConfig(@NonNull final EdgeDataEntity candidate, @NonNull final EdgeDataEntity head) {
+		if (!candidate.getConfiguration().equals(head.getConfiguration())) {
+			return false;
+		}
+		return Objects.equals(
+				EventUtils.getConfig(candidate.getEvent()),
+				EventUtils.getConfig(head.getEvent()));
+	}
+
+	/**
 	 * Delegates a single {@link DataEntity} to the existing {@link #processHit} path and
 	 * converts the boolean result to a {@link BatchOutcome}.
 	 */
@@ -257,66 +236,132 @@ class EdgeHitProcessor implements HitProcessing {
 	}
 
 	/**
-	 * Sends a batch network request and returns the full {@link RetryResult} (including
-	 * {@link EdgeNetworkService.NetworkRequestOutcome}) so {@link #processBatch} can act on
-	 * fine-grained outcomes like {@code EXPLODE_400}.
+	 * Builds the {@link EdgeHit} for one or more consecutive ExperienceEvents that share the head
+	 * entity's snapshotted configuration (identity map, datastream ID + overrides, implementation
+	 * details, endpoint). Used by both the batch path ({@link #processBatch}) and the single-event path
+	 * ({@link #processExperienceEventHit}), which is just the one-event case.
 	 *
-	 * <p>Mirrors the validation and logging logic of {@link #sendNetworkRequest}.
-	 *
-	 * @param entityId unique identifier of the head entity, used for retry-interval tracking
-	 * @param edgeHit  the assembled batch hit
-	 * @param requestHeaders HTTP headers to attach
-	 * @return {@link RetryResult} describing the outcome
+	 * @param headEdgeEntity the entity whose snapshotted config drives the request
+	 * @param events the ordered ExperienceEvents to include in the payload
+	 * @return the assembled {@link EdgeHit}, or null if the datastream ID is missing/empty or the
+	 *     payload could not be built (the caller decides how to treat a dropped hit)
 	 */
-	private RetryResult sendBatchNetworkRequest(
-			final String entityId,
-			final EdgeHit edgeHit,
-			final Map<String, String> requestHeaders) {
+	private EdgeHit buildExperienceEventHit(
+			@NonNull final EdgeDataEntity headEdgeEntity,
+			@NonNull final List<Event> events) {
+		final RequestBuilder request = new RequestBuilder(namedCollection);
+		request.addXdmPayload(headEdgeEntity.getIdentityMap());
+		request.enableResponseStreaming(
+				EdgeConstants.Defaults.REQUEST_CONFIG_RECORD_SEPARATOR,
+				EdgeConstants.Defaults.REQUEST_CONFIG_LINE_FEED
+		);
 
-		if (edgeHit == null || edgeHit.getPayload() == null || edgeHit.getPayload().length() == 0) {
-			Log.warning(LOG_TAG, LOG_SOURCE, "Batch request body was null/empty, dropping.");
-			return new RetryResult(EdgeNetworkService.NetworkRequestOutcome.DROP, 0);
+		if (stateCallback != null) {
+			// Add Implementation Details to request (global) level
+			request.addXdmPayload(stateCallback.getImplementationDetails());
 		}
 
-		final EdgeNetworkService.ResponseCallback responseCallback = new EdgeNetworkService.ResponseCallback() {
+		final Map<String, Object> edgeConfig = headEdgeEntity.getConfiguration();
+		String datastreamId = DataReader.optString(
+				edgeConfig, EdgeConstants.SharedState.Configuration.EDGE_CONFIG_ID, null);
+		final Map<String, Object> eventConfigMap = EventUtils.getConfig(headEdgeEntity.getEvent());
+		datastreamId = processEventConfigOverrides(eventConfigMap, request, datastreamId);
+
+		if (StringUtils.isNullOrEmpty(datastreamId)) {
+			// The Edge configuration ID value should get validated when creating the Hit,
+			// so we shouldn't get here in production.
+			Log.debug(LOG_TAG, LOG_SOURCE,
+					"Cannot process Experience Event hit as the Edge Network configuration ID is null or empty, dropping current event (%s).",
+					headEdgeEntity.getEvent().getUniqueIdentifier());
+			return null;
+		}
+
+		final JSONObject requestPayload = request.getPayloadWithExperienceEvents(events);
+		if (requestPayload == null) {
+			Log.warning(LOG_TAG, LOG_SOURCE, "Failed to build the request payload, dropping current event (%s).",
+					headEdgeEntity.getEvent().getUniqueIdentifier());
+			return null;
+		}
+
+		final Map<String, Object> requestProperties = getRequestProperties(headEdgeEntity.getEvent());
+		final EdgeEndpoint edgeEndpoint = getEdgeEndpoint(
+				EdgeNetworkService.RequestType.INTERACT, edgeConfig, requestProperties);
+		return new EdgeHit(datastreamId, requestPayload, edgeEndpoint);
+	}
+
+	/**
+	 * Builds the {@link EdgeNetworkService.ResponseCallback} that forwards streamed responses, errors,
+	 * and completion for {@code requestId} to the {@link NetworkResponseHandler}.
+	 */
+	private EdgeNetworkService.ResponseCallback buildResponseCallback(final String requestId) {
+		return new EdgeNetworkService.ResponseCallback() {
 			@Override
 			public void onResponse(final String jsonResponse) {
-				networkResponseHandler.processResponseOnSuccess(jsonResponse, edgeHit.getRequestId());
+				networkResponseHandler.processResponseOnSuccess(jsonResponse, requestId);
 			}
 
 			@Override
 			public void onError(final String jsonError) {
-				networkResponseHandler.processResponseOnError(jsonError, edgeHit.getRequestId());
+				networkResponseHandler.processResponseOnError(jsonError, requestId);
 			}
 
 			@Override
 			public void onComplete() {
-				networkResponseHandler.processResponseOnComplete(edgeHit.getRequestId());
+				networkResponseHandler.processResponseOnComplete(requestId);
 			}
 		};
+	}
+
+	/**
+	 * Sends {@code edgeHit} to the Edge Network and returns the full {@link RetryResult} (including the
+	 * granular {@link EdgeNetworkService.NetworkRequestOutcome}). Validates the payload and URL, logs the
+	 * request, and maintains {@code entityRetryIntervalMapping}. Never returns null — a null/empty
+	 * payload, malformed URL, or null network result all map to a {@code DROP} outcome.
+	 *
+	 * <p>Shared by the batch path (which acts on the granular outcome directly) and the single-event
+	 * wrapper {@link #sendNetworkRequest}.
+	 *
+	 * @param entityId unique identifier of the head entity, used for retry-interval tracking; may be null
+	 * @param edgeHit the assembled hit to send
+	 * @param requestHeaders HTTP headers to attach
+	 * @param isBatchRequest true if {@code edgeHit} carries more than one event and a 400 should be
+	 *                       exploded into individual resends; false for single-event requests, whose
+	 *                       400 handling must be identical to a non-batching build
+	 * @return the {@link RetryResult} describing the outcome; never null
+	 */
+	private RetryResult sendEdgeHit(
+			final String entityId,
+			final EdgeHit edgeHit,
+			final Map<String, String> requestHeaders,
+			final boolean isBatchRequest) {
+		if (edgeHit == null || edgeHit.getPayload() == null || edgeHit.getPayload().length() == 0) {
+			Log.warning(LOG_TAG, LOG_SOURCE, "Request body was null/empty, dropping this request.");
+			return new RetryResult(EdgeNetworkService.NetworkRequestOutcome.DROP, 0);
+		}
 
 		final String url = networkService.buildUrl(
 				edgeHit.getEdgeEndpoint(), edgeHit.getDatastreamId(), edgeHit.getRequestId());
 
 		if (!isValidUrl(url)) {
 			Log.warning(LOG_TAG, LOG_SOURCE,
-					"Unable to send batch request for entity (%s): URL is malformed, '%s'.",
+					"Unable to send network request for entity (%s) as URL is malformed or scheme is not 'https', '%s'.",
 					entityId, url);
 			return new RetryResult(EdgeNetworkService.NetworkRequestOutcome.DROP, 0);
 		}
 
 		try {
 			Log.debug(LOG_TAG, LOG_SOURCE,
-					"Sending batch request id (%s) to URL '%s' with body:\n%s",
+					"Sending network request with id (%s) to URL '%s' with body:\n%s",
 					edgeHit.getRequestId(), url, edgeHit.getPayload().toString(2));
 		} catch (JSONException e) {
 			Log.debug(LOG_TAG, LOG_SOURCE,
-					"Sending batch request id (%s) to URL '%s'. Error pretty-printing JSON: %s",
+					"Sending network request with id (%s) to URL '%s'. Error parsing JSON request: %s",
 					edgeHit.getRequestId(), url, e.getLocalizedMessage());
 		}
 
 		final RetryResult retryResult = networkService.doRequest(
-				url, edgeHit.getPayload().toString(), requestHeaders, responseCallback);
+				url, edgeHit.getPayload().toString(), requestHeaders, isBatchRequest,
+				buildResponseCallback(edgeHit.getRequestId()));
 
 		if (retryResult == null) {
 			return new RetryResult(EdgeNetworkService.NetworkRequestOutcome.DROP, 0);
@@ -332,62 +377,6 @@ class EdgeHitProcessor implements HitProcessing {
 		}
 
 		return retryResult;
-	}
-
-	/**
-	 * Re-sends each entity in {@code batchEntities} individually after a batch 400.
-	 *
-	 * <p>A 400 means nothing in the batch was ingested, so every event is safe to resend.
-	 * Entities are processed FIFO:
-	 * <ul>
-	 *   <li>Delivered / dropped (i.e. {@link #processHit} returns {@code true}) → counted as resolved.</li>
-	 *   <li>Recoverable failure (returns {@code false}) → stop; return the resolved count so the
-	 *       queue can remove those entities and schedule a retry for the remainder.</li>
-	 * </ul>
-	 *
-	 * @param batchEntities the entities that made up the failed batch, in original queue order
-	 * @return {@link BatchOutcome} directing the queue how to advance
-	 */
-	private BatchOutcome explodeAndResend(@NonNull final List<DataEntity> batchEntities) {
-		Log.debug(LOG_TAG, LOG_SOURCE,
-				"Exploding batch of %d events to individual requests.", batchEntities.size());
-
-		int resolvedCount = 0;
-		for (final DataEntity entity : batchEntities) {
-			// Each entity is sent as a batch-of-1, which goes through the same terminal path
-			// (handles SUCCESS, DROP, and the terminal-400 case that fires the error callback).
-			final BatchOutcome outcome = processBatch(Collections.singletonList(entity));
-
-			switch (outcome.getKind()) {
-				case DONE:
-					resolvedCount++;
-					Log.trace(LOG_TAG, LOG_SOURCE,
-							"Explosion: event %d/%d resolved.", resolvedCount, batchEntities.size());
-					break;
-
-				case RETRY_BATCH:
-					// Recoverable failure — stop exploding. Leave this entity (and everything after)
-					// in the queue so the normal retry cycle handles them.
-					final int delay = outcome.getRetryAfterSeconds();
-					Log.debug(LOG_TAG, LOG_SOURCE,
-							"Explosion: event at position %d/%d needs retry in %d seconds; "
-									+ "%d preceding events resolved.",
-							resolvedCount + 1, batchEntities.size(), delay, resolvedCount);
-					if (resolvedCount > 0) {
-						return BatchOutcome.partialRemove(resolvedCount, delay);
-					}
-					return BatchOutcome.retryBatch(delay);
-
-				default:
-					// PARTIAL_REMOVE cannot occur for a size-1 processBatch call.
-					resolvedCount++;
-					break;
-			}
-		}
-
-		Log.debug(LOG_TAG, LOG_SOURCE,
-				"Explosion complete: all %d events resolved.", batchEntities.size());
-		return BatchOutcome.done(resolvedCount);
 	}
 
 	/**
@@ -409,21 +398,11 @@ class EdgeHitProcessor implements HitProcessing {
 			return;
 		}
 
-		// Add in Identity Map at request (global) level
-		RequestBuilder request = new RequestBuilder(namedCollection);
-		request.addXdmPayload(entity.getIdentityMap());
-
-		// Enable response streaming for all events
-		request.enableResponseStreaming(
-			EdgeConstants.Defaults.REQUEST_CONFIG_RECORD_SEPARATOR,
-			EdgeConstants.Defaults.REQUEST_CONFIG_LINE_FEED
-		);
-
 		boolean hitCompleteResult = true;
 		if (EventUtils.isExperienceEvent(entity.getEvent())) {
-			hitCompleteResult = processExperienceEventHit(dataEntity.getUniqueIdentifier(), entity, request);
+			hitCompleteResult = processExperienceEventHit(dataEntity.getUniqueIdentifier(), entity);
 		} else if (EventUtils.isUpdateConsentEvent(entity.getEvent())) {
-			hitCompleteResult = processUpdateConsentEventHit(dataEntity.getUniqueIdentifier(), entity, request);
+			hitCompleteResult = processUpdateConsentEventHit(dataEntity.getUniqueIdentifier(), entity);
 		} else if (EventUtils.isResetComplete(entity.getEvent())) {
 			// clear state store
 			final StoreResponsePayloadManager payloadManager = new StoreResponsePayloadManager(namedCollection);
@@ -435,22 +414,6 @@ class EdgeHitProcessor implements HitProcessing {
 	}
 
 	/**
-	 * Delivers a terminal 400 error for the given {@code requestId}: processes the server error
-	 * body through the response handler (dispatching error events to waiting events) and then
-	 * fires completion (removing waiting state and unregistering callbacks).
-	 *
-	 * <p>Used for any single-event 400 — whether from {@link #processBatch} (batch-of-1) or from
-	 * {@link #sendNetworkRequest} (Consent/Reset paths).
-	 *
-	 * @param requestId  the Edge request ID whose waiting events should receive the error
-	 * @param errorBody  the JSON error body captured from the 400 response; may be null
-	 */
-	private void deliverTerminalBadRequest(final String requestId, final String errorBody) {
-		networkResponseHandler.processResponseOnError(errorBody, requestId);
-		networkResponseHandler.processResponseOnComplete(requestId);
-	}
-
-	/**
 	 * Sends a network call to Experience Edge Network with the provided information in {@link EdgeHit}.
 	 * Two response handlers are registered for this network request, for response content and eventual request errors.
 	 * @param entityId the unique id of the entity being processed
@@ -459,97 +422,8 @@ class EdgeHitProcessor implements HitProcessing {
 	 * @return true if sending the hit is complete, false if sending the hit should be retried at a later time
 	 */
 	boolean sendNetworkRequest(final String entityId, final EdgeHit edgeHit, final Map<String, String> requestHeaders) {
-		if (edgeHit == null || edgeHit.getPayload() == null || edgeHit.getPayload().length() == 0) {
-			Log.warning(LOG_TAG, LOG_SOURCE, "Request body was null/empty, dropping this request");
-			return true;
-		}
-
-		EdgeNetworkService.ResponseCallback responseCallback = new EdgeNetworkService.ResponseCallback() {
-			@Override
-			public void onResponse(final String jsonResponse) {
-				networkResponseHandler.processResponseOnSuccess(jsonResponse, edgeHit.getRequestId());
-			}
-
-			@Override
-			public void onError(final String jsonError) {
-				networkResponseHandler.processResponseOnError(jsonError, edgeHit.getRequestId());
-			}
-
-			@Override
-			public void onComplete() {
-				networkResponseHandler.processResponseOnComplete(edgeHit.getRequestId());
-			}
-		};
-
-		String url = networkService.buildUrl(
-			edgeHit.getEdgeEndpoint(),
-			edgeHit.getDatastreamId(),
-			edgeHit.getRequestId()
-		);
-
-		if (!isValidUrl(url)) {
-			Log.warning(
-				LOG_TAG,
-				LOG_SOURCE,
-				"Unable to send network request for entity (%s) as URL is malformed or scheme is not 'https', '%s'.",
-				entityId,
-				url
-			);
-
-			return true;
-		}
-
-		try {
-			Log.debug(
-				LOG_TAG,
-				LOG_SOURCE,
-				"Sending network request with id (%s) to URL '%s' with body:\n%s",
-				edgeHit.getRequestId(),
-				url,
-				edgeHit.getPayload().toString(2)
-			);
-		} catch (JSONException e) {
-			Log.debug(
-				LOG_TAG,
-				LOG_SOURCE,
-				"Sending network request with id (%s) to URL '%s'\nError parsing JSON request: %s",
-				edgeHit.getRequestId(),
-				url,
-				e.getLocalizedMessage()
-			);
-		}
-
-		RetryResult retryResult = networkService.doRequest(
-			url,
-			edgeHit.getPayload().toString(),
-			requestHeaders,
-			responseCallback
-		);
-
-		if (retryResult == null || retryResult.getShouldRetry() == EdgeNetworkService.Retry.NO) {
-			if (entityId != null) {
-				entityRetryIntervalMapping.remove(entityId);
-			}
-
-			// Consent/Reset events are always terminal. A 400 here is never exploded — deliver
-			// the real error body directly and fire completion so the caller sees it.
-			if (retryResult != null
-					&& retryResult.getNetworkRequestOutcome()
-						== EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400) {
-				deliverTerminalBadRequest(edgeHit.getRequestId(), retryResult.getResponseBody());
-			}
-
-			return true; // Hit complete (success, drop, or terminal 400)
-		} else {
-			if (
-				entityId != null &&
-				retryResult.getRetryIntervalSeconds() != EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS
-			) {
-				entityRetryIntervalMapping.put(entityId, retryResult.getRetryIntervalSeconds());
-			}
-
-			return false; // Hit failed to send, retry after interval
-		}
+		final RetryResult result = sendEdgeHit(entityId, edgeHit, requestHeaders, false);
+		return result.getShouldRetry() != EdgeNetworkService.Retry.YES;
 	}
 
 	/**
@@ -620,79 +494,31 @@ class EdgeHitProcessor implements HitProcessing {
 	}
 
 	/**
-	 * Process and send an ExperienceEvent network request.
+	 * Process and send a single ExperienceEvent network request. This is the one-event case of a batch;
+	 * both share {@link #buildExperienceEventHit}.
 	 *
 	 * @param entityId the {@link DataEntity} unique identifier
 	 * @param entity the {@link EdgeDataEntity} which encapsulates the request data
-	 * @param request a {@link RequestBuilder} instance
 	 * @return true if the request processing is complete for this hit or false if processing is
 	 * not complete and this hit must be retired.
 	 */
 	private boolean processExperienceEventHit(
 		@NonNull final String entityId,
-		@NonNull final EdgeDataEntity entity,
-		@NonNull final RequestBuilder request
+		@NonNull final EdgeDataEntity entity
 	) {
-		if (stateCallback != null) {
-			// Add Implementation Details to request (global) level
-			request.addXdmPayload(stateCallback.getImplementationDetails());
-		}
-
-		Map<String, Object> edgeConfig = entity.getConfiguration();
-
-		String datastreamId = DataReader.optString(
-			edgeConfig,
-			EdgeConstants.SharedState.Configuration.EDGE_CONFIG_ID,
-			null
-		);
-
-		// Get config map containing overrides from the event
-		Map<String, Object> eventConfigMap = EventUtils.getConfig(entity.getEvent());
-
-		datastreamId = processEventConfigOverrides(eventConfigMap, request, datastreamId);
-
-		if (StringUtils.isNullOrEmpty(datastreamId)) {
-			// The Edge configuration ID value should get validated when creating the Hit,
-			// so we shouldn't get here in production.
-			Log.debug(
-				LOG_TAG,
-				LOG_SOURCE,
-				"Cannot process Experience Event hit as the Edge Network configuration ID is null or empty, dropping current event (%s).",
-				entity.getEvent().getUniqueIdentifier()
-			);
-			return true; // Request complete, don't retry hit
-		}
-
 		final List<Event> listOfEvents = new ArrayList<>();
 		listOfEvents.add(entity.getEvent());
-		final JSONObject requestPayload = request.getPayloadWithExperienceEvents(listOfEvents);
 
-		if (requestPayload == null) {
-			Log.warning(
-				LOG_TAG,
-				LOG_SOURCE,
-				"Failed to build the request payload, dropping current event (%s).",
-				entity.getEvent().getUniqueIdentifier()
-			);
-
-			return true; // Request complete, don't retry hit
+		final EdgeHit edgeHit = buildExperienceEventHit(entity, listOfEvents);
+		if (edgeHit == null) {
+			return true; // Config ID missing/empty or payload build failed — request complete, don't retry.
 		}
-
-		Map<String, Object> requestProperties = getRequestProperties(entity.getEvent());
-		final EdgeEndpoint edgeEndpoint = getEdgeEndpoint(
-			EdgeNetworkService.RequestType.INTERACT,
-			edgeConfig,
-			requestProperties
-		);
-
-		final EdgeHit edgeHit = new EdgeHit(datastreamId, requestPayload, edgeEndpoint);
 
 		// NOTE: the order of these events need to be maintained as they were sent in the network request
 		// otherwise the response callback cannot be matched
 		networkResponseHandler.addWaitingEvents(edgeHit.getRequestId(), listOfEvents);
 
-		final Map<String, String> requestHeaders = getRequestHeaders();
-		return sendNetworkRequest(entityId, edgeHit, requestHeaders);
+		return sendNetworkRequest(entityId, edgeHit, getRequestHeaders());
 	}
 
 	/**
@@ -700,16 +526,21 @@ class EdgeHitProcessor implements HitProcessing {
 	 *
 	 * @param entityId the {@link DataEntity} unique identifier
 	 * @param entity the {@link EdgeDataEntity} which encapsulates the request data
-	 * @param request a {@link RequestBuilder} instance
 	 * @return true if the request processing is complete for this hit or false if processing is
 	 * not complete and this hit must be retired.
 	 */
 	private boolean processUpdateConsentEventHit(
 		@NonNull final String entityId,
-		@NonNull final EdgeDataEntity entity,
-		@NonNull final RequestBuilder request
+		@NonNull final EdgeDataEntity entity
 	) {
-		// Build and send the consent network request to Experience Edge
+		// Add Identity Map (global) and enable response streaming, then build the consent payload.
+		final RequestBuilder request = new RequestBuilder(namedCollection);
+		request.addXdmPayload(entity.getIdentityMap());
+		request.enableResponseStreaming(
+			EdgeConstants.Defaults.REQUEST_CONFIG_RECORD_SEPARATOR,
+			EdgeConstants.Defaults.REQUEST_CONFIG_LINE_FEED
+		);
+
 		final JSONObject consentPayload = request.getConsentPayload(entity.getEvent());
 
 		if (consentPayload == null) {

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
@@ -107,13 +107,25 @@ class EdgeHitProcessor implements HitProcessing {
 			return processSingleEntity(headEntity);
 		}
 
+		// Events whose name isn't in the configured allowlist must also be processed alone.
+		if (!isEventNameAllowlistedForBatching(headEdgeEntity)) {
+			Log.trace(LOG_TAG, LOG_SOURCE,
+					"Head entity's event name (%s) is not in the batching allowlist; processing alone.",
+					headEdgeEntity.getEvent().getName());
+			return processSingleEntity(headEntity);
+		}
+
 		// Collect the consecutive ExperienceEvent run from the front.
 		final List<DataEntity> batchEntities = new ArrayList<>();
 		final List<Event> batchEvents = new ArrayList<>();
 
 		for (final DataEntity dataEntity : entities) {
 			final EdgeDataEntity edgeEntity = EdgeDataEntity.fromDataEntity(dataEntity);
-			if (edgeEntity == null || !EventUtils.isExperienceEvent(edgeEntity.getEvent())) {
+			if (
+				edgeEntity == null ||
+				!EventUtils.isExperienceEvent(edgeEntity.getEvent()) ||
+				!isEventNameAllowlistedForBatching(edgeEntity)
+			) {
 				break;
 			}
 			batchEntities.add(dataEntity);
@@ -205,6 +217,30 @@ class EdgeHitProcessor implements HitProcessing {
 			default:
 				return BatchOutcome.done(batchEntities.size());
 		}
+	}
+
+	/**
+	 * Checks whether {@code entity}'s underlying {@link Event} name is present in the
+	 * {@code edge.batching.eventNameAllowlist} configuration snapshotted on this entity at
+	 * enqueue time. An absent or empty allowlist means no event names are eligible for
+	 * batching (opt-in allowlist semantics) — {@code edge.batching.enabled} alone is not
+	 * sufficient to batch a given event.
+	 *
+	 * @param entity the {@link EdgeDataEntity} whose event name is being checked
+	 * @return true if the entity's event name is explicitly allowlisted for batching
+	 */
+	private boolean isEventNameAllowlistedForBatching(@NonNull final EdgeDataEntity entity) {
+		final List<String> allowlist = DataReader.optStringList(
+			entity.getConfiguration(),
+			EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST,
+			null
+		);
+
+		if (allowlist == null || allowlist.isEmpty()) {
+			return false;
+		}
+
+		return allowlist.contains(entity.getEvent().getName());
 	}
 
 	/**

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
@@ -127,9 +127,12 @@ class EdgeHitProcessor implements HitProcessing {
 		// process the head alone via the existing single-entity path (consent, reset, non-allowlisted,
 		// and single-Experience-event cases all funnel here).
 		if (batchEntities.size() <= 1) {
-			Log.trace(LOG_TAG, LOG_SOURCE,
-					"Head entity (%s) is not batchable or is the only batchable entity; processing alone.",
-					headEdgeEntity.getEvent().getName());
+			Log.trace(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Head entity (%s) is not batchable or is the only batchable entity; processing alone.",
+				headEdgeEntity.getEvent().getName()
+			);
 			return processSingleEntity(headEntity);
 		}
 
@@ -148,31 +151,42 @@ class EdgeHitProcessor implements HitProcessing {
 
 		switch (result.getNetworkRequestOutcome()) {
 			case SUCCESS:
-				Log.debug(LOG_TAG, LOG_SOURCE,
-						"Batch of %d events sent and processed successfully.", batchEntities.size());
+				Log.debug(
+					LOG_TAG,
+					LOG_SOURCE,
+					"Batch of %d events sent and processed successfully.",
+					batchEntities.size()
+				);
 				return BatchOutcome.done(batchEntities.size());
-
 			case RETRY:
-				Log.debug(LOG_TAG, LOG_SOURCE,
-						"Batch of %d events will be retried in %d seconds.",
-						batchEntities.size(), result.getRetryIntervalSeconds());
+				Log.debug(
+					LOG_TAG,
+					LOG_SOURCE,
+					"Batch of %d events will be retried in %d seconds.",
+					batchEntities.size(),
+					result.getRetryIntervalSeconds()
+				);
 				return BatchOutcome.retryBatch(result.getRetryIntervalSeconds());
-
 			case EXPLODE_400:
 				// Batch of N>1 nothing ingested — clean up waiting state and tell the queue to drain
 				// these entities one at a time via the ordinary single-event path (see
 				// EdgeBatchingHitQueue#runBatchCycle).
-				Log.warning(LOG_TAG, LOG_SOURCE,
-						"Batch of %d events received 400; draining individually.",
-						batchEntities.size());
+				Log.warning(
+					LOG_TAG,
+					LOG_SOURCE,
+					"Batch of %d events received 400; draining individually.",
+					batchEntities.size()
+				);
 				networkResponseHandler.removeWaitingEvents(edgeHit.getRequestId());
 				return BatchOutcome.explode(batchEntities.size());
-
 			case DROP:
 			default:
-				Log.warning(LOG_TAG, LOG_SOURCE,
-						"Batch of %d events received non-recoverable error; dropping all.",
-						batchEntities.size());
+				Log.warning(
+					LOG_TAG,
+					LOG_SOURCE,
+					"Batch of %d events received non-recoverable error; dropping all.",
+					batchEntities.size()
+				);
 				return BatchOutcome.done(batchEntities.size());
 		}
 	}
@@ -217,9 +231,7 @@ class EdgeHitProcessor implements HitProcessing {
 		if (!candidate.getConfiguration().equals(head.getConfiguration())) {
 			return false;
 		}
-		return Objects.equals(
-				EventUtils.getConfig(candidate.getEvent()),
-				EventUtils.getConfig(head.getEvent()));
+		return Objects.equals(EventUtils.getConfig(candidate.getEvent()), EventUtils.getConfig(head.getEvent()));
 	}
 
 	/**
@@ -247,13 +259,14 @@ class EdgeHitProcessor implements HitProcessing {
 	 *     payload could not be built (the caller decides how to treat a dropped hit)
 	 */
 	private EdgeHit buildExperienceEventHit(
-			@NonNull final EdgeDataEntity headEdgeEntity,
-			@NonNull final List<Event> events) {
+		@NonNull final EdgeDataEntity headEdgeEntity,
+		@NonNull final List<Event> events
+	) {
 		final RequestBuilder request = new RequestBuilder(namedCollection);
 		request.addXdmPayload(headEdgeEntity.getIdentityMap());
 		request.enableResponseStreaming(
-				EdgeConstants.Defaults.REQUEST_CONFIG_RECORD_SEPARATOR,
-				EdgeConstants.Defaults.REQUEST_CONFIG_LINE_FEED
+			EdgeConstants.Defaults.REQUEST_CONFIG_RECORD_SEPARATOR,
+			EdgeConstants.Defaults.REQUEST_CONFIG_LINE_FEED
 		);
 
 		if (stateCallback != null) {
@@ -263,29 +276,42 @@ class EdgeHitProcessor implements HitProcessing {
 
 		final Map<String, Object> edgeConfig = headEdgeEntity.getConfiguration();
 		String datastreamId = DataReader.optString(
-				edgeConfig, EdgeConstants.SharedState.Configuration.EDGE_CONFIG_ID, null);
+			edgeConfig,
+			EdgeConstants.SharedState.Configuration.EDGE_CONFIG_ID,
+			null
+		);
 		final Map<String, Object> eventConfigMap = EventUtils.getConfig(headEdgeEntity.getEvent());
 		datastreamId = processEventConfigOverrides(eventConfigMap, request, datastreamId);
 
 		if (StringUtils.isNullOrEmpty(datastreamId)) {
 			// The Edge configuration ID value should get validated when creating the Hit,
 			// so we shouldn't get here in production.
-			Log.debug(LOG_TAG, LOG_SOURCE,
-					"Cannot process Experience Event hit as the Edge Network configuration ID is null or empty, dropping current event (%s).",
-					headEdgeEntity.getEvent().getUniqueIdentifier());
+			Log.debug(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Cannot process Experience Event hit as the Edge Network configuration ID is null or empty, dropping current event (%s).",
+				headEdgeEntity.getEvent().getUniqueIdentifier()
+			);
 			return null;
 		}
 
 		final JSONObject requestPayload = request.getPayloadWithExperienceEvents(events);
 		if (requestPayload == null) {
-			Log.warning(LOG_TAG, LOG_SOURCE, "Failed to build the request payload, dropping current event (%s).",
-					headEdgeEntity.getEvent().getUniqueIdentifier());
+			Log.warning(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Failed to build the request payload, dropping current event (%s).",
+				headEdgeEntity.getEvent().getUniqueIdentifier()
+			);
 			return null;
 		}
 
 		final Map<String, Object> requestProperties = getRequestProperties(headEdgeEntity.getEvent());
 		final EdgeEndpoint edgeEndpoint = getEdgeEndpoint(
-				EdgeNetworkService.RequestType.INTERACT, edgeConfig, requestProperties);
+			EdgeNetworkService.RequestType.INTERACT,
+			edgeConfig,
+			requestProperties
+		);
 		return new EdgeHit(datastreamId, requestPayload, edgeEndpoint);
 	}
 
@@ -330,38 +356,60 @@ class EdgeHitProcessor implements HitProcessing {
 	 * @return the {@link RetryResult} describing the outcome; never null
 	 */
 	private RetryResult sendEdgeHit(
-			final String entityId,
-			final EdgeHit edgeHit,
-			final Map<String, String> requestHeaders,
-			final boolean isBatchRequest) {
+		final String entityId,
+		final EdgeHit edgeHit,
+		final Map<String, String> requestHeaders,
+		final boolean isBatchRequest
+	) {
 		if (edgeHit == null || edgeHit.getPayload() == null || edgeHit.getPayload().length() == 0) {
 			Log.warning(LOG_TAG, LOG_SOURCE, "Request body was null/empty, dropping this request.");
 			return new RetryResult(EdgeNetworkService.NetworkRequestOutcome.DROP, 0);
 		}
 
 		final String url = networkService.buildUrl(
-				edgeHit.getEdgeEndpoint(), edgeHit.getDatastreamId(), edgeHit.getRequestId());
+			edgeHit.getEdgeEndpoint(),
+			edgeHit.getDatastreamId(),
+			edgeHit.getRequestId()
+		);
 
 		if (!isValidUrl(url)) {
-			Log.warning(LOG_TAG, LOG_SOURCE,
-					"Unable to send network request for entity (%s) as URL is malformed or scheme is not 'https', '%s'.",
-					entityId, url);
+			Log.warning(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Unable to send network request for entity (%s) as URL is malformed or scheme is not 'https', '%s'.",
+				entityId,
+				url
+			);
 			return new RetryResult(EdgeNetworkService.NetworkRequestOutcome.DROP, 0);
 		}
 
 		try {
-			Log.debug(LOG_TAG, LOG_SOURCE,
-					"Sending network request with id (%s) to URL '%s' with body:\n%s",
-					edgeHit.getRequestId(), url, edgeHit.getPayload().toString(2));
+			Log.debug(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Sending network request with id (%s) to URL '%s' with body:\n%s",
+				edgeHit.getRequestId(),
+				url,
+				edgeHit.getPayload().toString(2)
+			);
 		} catch (JSONException e) {
-			Log.debug(LOG_TAG, LOG_SOURCE,
-					"Sending network request with id (%s) to URL '%s'. Error parsing JSON request: %s",
-					edgeHit.getRequestId(), url, e.getLocalizedMessage());
+			Log.debug(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Sending network request with id (%s) to URL '%s'. Error parsing JSON request: %s",
+				edgeHit.getRequestId(),
+				url,
+				e.getLocalizedMessage()
+			);
 		}
 
 		final RetryResult retryResult = networkService.doRequest(
-				url, edgeHit.getPayload().toString(), requestHeaders, isBatchRequest,
-				buildResponseCallback(edgeHit.getRequestId()));
+			url,
+			edgeHit.getPayload().toString(),
+			requestHeaders,
+			isBatchRequest,
+			buildResponseCallback(edgeHit.getRequestId())
+		);
 
 		if (retryResult == null) {
 			return new RetryResult(EdgeNetworkService.NetworkRequestOutcome.DROP, 0);
@@ -371,8 +419,9 @@ class EdgeHitProcessor implements HitProcessing {
 			if (entityId != null) {
 				entityRetryIntervalMapping.remove(entityId);
 			}
-		} else if (entityId != null
-				&& retryResult.getRetryIntervalSeconds() != EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS) {
+		} else if (
+			entityId != null && retryResult.getRetryIntervalSeconds() != EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS
+		) {
 			entityRetryIntervalMapping.put(entityId, retryResult.getRetryIntervalSeconds());
 		}
 
@@ -502,10 +551,7 @@ class EdgeHitProcessor implements HitProcessing {
 	 * @return true if the request processing is complete for this hit or false if processing is
 	 * not complete and this hit must be retired.
 	 */
-	private boolean processExperienceEventHit(
-		@NonNull final String entityId,
-		@NonNull final EdgeDataEntity entity
-	) {
+	private boolean processExperienceEventHit(@NonNull final String entityId, @NonNull final EdgeDataEntity entity) {
 		final List<Event> listOfEvents = new ArrayList<>();
 		listOfEvents.add(entity.getEvent());
 
@@ -529,10 +575,7 @@ class EdgeHitProcessor implements HitProcessing {
 	 * @return true if the request processing is complete for this hit or false if processing is
 	 * not complete and this hit must be retired.
 	 */
-	private boolean processUpdateConsentEventHit(
-		@NonNull final String entityId,
-		@NonNull final EdgeDataEntity entity
-	) {
+	private boolean processUpdateConsentEventHit(@NonNull final String entityId, @NonNull final EdgeDataEntity entity) {
 		// Add Identity Map (global) and enable response streaming, then build the consent payload.
 		final RequestBuilder request = new RequestBuilder(namedCollection);
 		request.addXdmPayload(entity.getIdentityMap());

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeHitProcessor.java
@@ -26,6 +26,7 @@ import com.adobe.marketing.mobile.util.MapUtils;
 import com.adobe.marketing.mobile.util.StringUtils;
 import com.adobe.marketing.mobile.util.UrlUtils;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,6 +73,296 @@ class EdgeHitProcessor implements HitProcessing {
 	}
 
 	/**
+	 * Processes a batch of {@link DataEntity}s as a single network request when the batch contains
+	 * more than one ExperienceEvent; otherwise delegates to the existing single-entity path.
+	 *
+	 * <p>Routing rules:
+	 * <ul>
+	 *   <li>Head is not an ExperienceEvent → process head alone (consent, reset, etc.).</li>
+	 *   <li>Batch size == 1 OR only head qualifies → single-entity path.</li>
+	 *   <li>Multiple consecutive ExperienceEvents → build a batch request; on 400, explode to
+	 *       individual sends; on other non-recoverable, drop all and error.</li>
+	 * </ul>
+	 *
+	 * @param entities ordered list of entities to process; never null, never empty
+	 * @return {@link BatchOutcome} instructing the queue how to advance
+	 */
+	BatchOutcome processBatch(@NonNull final List<DataEntity> entities) {
+		if(entities.isEmpty()) return BatchOutcome.done();
+
+		final DataEntity headEntity = entities.get(0);
+		final EdgeDataEntity headEdgeEntity = EdgeDataEntity.fromDataEntity(headEntity);
+
+		if (headEdgeEntity == null) {
+			Log.debug(LOG_TAG, LOG_SOURCE,
+					"Unable to deserialize head entity to EdgeDataEntity, dropping.");
+			return BatchOutcome.done();
+		}
+
+		// Non-experience events (consent, reset) must be processed alone.
+		if (!EventUtils.isExperienceEvent(headEdgeEntity.getEvent())) {
+			Log.trace(LOG_TAG, LOG_SOURCE,
+					"Head entity is not an ExperienceEvent (%s); processing alone.",
+					headEdgeEntity.getEvent().getType());
+			return processSingleEntity(headEntity);
+		}
+
+		// Collect the consecutive ExperienceEvent run from the front.
+		final List<DataEntity> batchEntities = new ArrayList<>();
+		final List<Event> batchEvents = new ArrayList<>();
+
+		for (final DataEntity dataEntity : entities) {
+			final EdgeDataEntity edgeEntity = EdgeDataEntity.fromDataEntity(dataEntity);
+			if (edgeEntity == null || !EventUtils.isExperienceEvent(edgeEntity.getEvent())) {
+				break;
+			}
+			batchEntities.add(dataEntity);
+			batchEvents.add(edgeEntity.getEvent());
+		}
+
+		Log.debug(LOG_TAG, LOG_SOURCE,
+				"Processing batch of %d ExperienceEvent(s).", batchEntities.size());
+
+		// Build batch request using the head entity's snapshotted configuration.
+		final RequestBuilder request = new RequestBuilder(namedCollection);
+		request.addXdmPayload(headEdgeEntity.getIdentityMap());
+		request.enableResponseStreaming(
+				EdgeConstants.Defaults.REQUEST_CONFIG_RECORD_SEPARATOR,
+				EdgeConstants.Defaults.REQUEST_CONFIG_LINE_FEED
+		);
+
+		if (stateCallback != null) {
+			request.addXdmPayload(stateCallback.getImplementationDetails());
+		}
+
+		final Map<String, Object> edgeConfig = headEdgeEntity.getConfiguration();
+		String datastreamId = DataReader.optString(
+				edgeConfig, EdgeConstants.SharedState.Configuration.EDGE_CONFIG_ID, null);
+		final Map<String, Object> headEventConfigMap = EventUtils.getConfig(headEdgeEntity.getEvent());
+		datastreamId = processEventConfigOverrides(headEventConfigMap, request, datastreamId);
+
+		if (StringUtils.isNullOrEmpty(datastreamId)) {
+			Log.debug(LOG_TAG, LOG_SOURCE,
+					"Cannot process batch: Edge config ID is null/empty, dropping %d events.",
+					batchEntities.size());
+			return BatchOutcome.done();
+		}
+
+		final JSONObject requestPayload = request.getPayloadWithExperienceEvents(batchEvents);
+		if (requestPayload == null) {
+			Log.warning(LOG_TAG, LOG_SOURCE,
+					"Failed to build batch request payload, dropping %d events.", batchEntities.size());
+			return BatchOutcome.done();
+		}
+
+		final Map<String, Object> requestProperties = getRequestProperties(headEdgeEntity.getEvent());
+		final EdgeEndpoint edgeEndpoint = getEdgeEndpoint(
+				EdgeNetworkService.RequestType.INTERACT, edgeConfig, requestProperties);
+		final EdgeHit edgeHit = new EdgeHit(datastreamId, requestPayload, edgeEndpoint);
+
+		// Register all events before the network call so response fragments can be routed.
+		networkResponseHandler.addWaitingEvents(edgeHit.getRequestId(), batchEvents);
+
+		final Map<String, String> requestHeaders = getRequestHeaders();
+		// Measure the full request round trip (connect + response read + onComplete) — doRequest is
+		// synchronous, so this spans send → response received for this request id.
+		final long startNanos = System.nanoTime();
+		final RetryResult result = sendBatchNetworkRequest(
+				headEntity.getUniqueIdentifier(), edgeHit, requestHeaders);
+		final long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+		Log.debug(LOG_TAG, LOG_SOURCE,
+				"Round trip for request id (%s) with %d event(s): %d ms (outcome=%s).",
+				edgeHit.getRequestId(), batchEntities.size(), elapsedMs,
+				result.getNetworkRequestOutcome());
+
+		switch (result.getNetworkRequestOutcome()) {
+			case SUCCESS:
+				Log.debug(LOG_TAG, LOG_SOURCE,
+						"Batch of %d events sent and processed successfully.", batchEntities.size());
+				return BatchOutcome.done();
+
+			case RETRY:
+				Log.debug(LOG_TAG, LOG_SOURCE,
+						"Batch of %d events will be retried in %d seconds.",
+						batchEntities.size(), result.getRetryIntervalSeconds());
+				return BatchOutcome.retryBatch(result.getRetryIntervalSeconds());
+
+			case EXPLODE_400:
+				if (batchEntities.size() == 1) {
+					// Terminal: single event got a 400 — deliver the real error and fire completion.
+					Log.warning(LOG_TAG, LOG_SOURCE,
+							"Single event received 400; delivering terminal error for request id (%s).",
+							edgeHit.getRequestId());
+					deliverTerminalBadRequest(edgeHit.getRequestId(), result.getResponseBody());
+					return BatchOutcome.done();
+				} else {
+					// Batch of N>1: nothing ingested — clean up waiting state then explode.
+					Log.warning(LOG_TAG, LOG_SOURCE,
+							"Batch of %d events received 400; exploding to individual requests.",
+							batchEntities.size());
+					networkResponseHandler.removeWaitingEvents(edgeHit.getRequestId());
+					return explodeAndResend(batchEntities);
+				}
+
+			case DROP:
+				Log.warning(LOG_TAG, LOG_SOURCE,
+						"Batch of %d events received non-recoverable error; dropping all.",
+						batchEntities.size());
+				return BatchOutcome.done();
+
+			default:
+				return BatchOutcome.done();
+		}
+	}
+
+	/**
+	 * Delegates a single {@link DataEntity} to the existing {@link #processHit} path and
+	 * converts the boolean result to a {@link BatchOutcome}.
+	 */
+	private BatchOutcome processSingleEntity(@NonNull final DataEntity entity) {
+		final boolean[] done = { true };
+		processHit(entity, result -> done[0] = result);
+		if (done[0]) {
+			return BatchOutcome.done();
+		}
+		return BatchOutcome.retryBatch(retryInterval(entity));
+	}
+
+	/**
+	 * Sends a batch network request and returns the full {@link RetryResult} (including
+	 * {@link EdgeNetworkService.NetworkRequestOutcome}) so {@link #processBatch} can act on
+	 * fine-grained outcomes like {@code EXPLODE_400}.
+	 *
+	 * <p>Mirrors the validation and logging logic of {@link #sendNetworkRequest}.
+	 *
+	 * @param entityId unique identifier of the head entity, used for retry-interval tracking
+	 * @param edgeHit  the assembled batch hit
+	 * @param requestHeaders HTTP headers to attach
+	 * @return {@link RetryResult} describing the outcome
+	 */
+	private RetryResult sendBatchNetworkRequest(
+			final String entityId,
+			final EdgeHit edgeHit,
+			final Map<String, String> requestHeaders) {
+
+		if (edgeHit == null || edgeHit.getPayload() == null || edgeHit.getPayload().length() == 0) {
+			Log.warning(LOG_TAG, LOG_SOURCE, "Batch request body was null/empty, dropping.");
+			return new RetryResult(EdgeNetworkService.NetworkRequestOutcome.DROP, 0);
+		}
+
+		final EdgeNetworkService.ResponseCallback responseCallback = new EdgeNetworkService.ResponseCallback() {
+			@Override
+			public void onResponse(final String jsonResponse) {
+				networkResponseHandler.processResponseOnSuccess(jsonResponse, edgeHit.getRequestId());
+			}
+
+			@Override
+			public void onError(final String jsonError) {
+				networkResponseHandler.processResponseOnError(jsonError, edgeHit.getRequestId());
+			}
+
+			@Override
+			public void onComplete() {
+				networkResponseHandler.processResponseOnComplete(edgeHit.getRequestId());
+			}
+		};
+
+		final String url = networkService.buildUrl(
+				edgeHit.getEdgeEndpoint(), edgeHit.getDatastreamId(), edgeHit.getRequestId());
+
+		if (!isValidUrl(url)) {
+			Log.warning(LOG_TAG, LOG_SOURCE,
+					"Unable to send batch request for entity (%s): URL is malformed, '%s'.",
+					entityId, url);
+			return new RetryResult(EdgeNetworkService.NetworkRequestOutcome.DROP, 0);
+		}
+
+		try {
+			Log.debug(LOG_TAG, LOG_SOURCE,
+					"Sending batch request id (%s) to URL '%s' with body:\n%s",
+					edgeHit.getRequestId(), url, edgeHit.getPayload().toString(2));
+		} catch (JSONException e) {
+			Log.debug(LOG_TAG, LOG_SOURCE,
+					"Sending batch request id (%s) to URL '%s'. Error pretty-printing JSON: %s",
+					edgeHit.getRequestId(), url, e.getLocalizedMessage());
+		}
+
+		final RetryResult retryResult = networkService.doRequest(
+				url, edgeHit.getPayload().toString(), requestHeaders, responseCallback);
+
+		if (retryResult == null) {
+			return new RetryResult(EdgeNetworkService.NetworkRequestOutcome.DROP, 0);
+		}
+
+		if (retryResult.getShouldRetry() == EdgeNetworkService.Retry.NO) {
+			if (entityId != null) {
+				entityRetryIntervalMapping.remove(entityId);
+			}
+		} else if (entityId != null
+				&& retryResult.getRetryIntervalSeconds() != EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS) {
+			entityRetryIntervalMapping.put(entityId, retryResult.getRetryIntervalSeconds());
+		}
+
+		return retryResult;
+	}
+
+	/**
+	 * Re-sends each entity in {@code batchEntities} individually after a batch 400.
+	 *
+	 * <p>A 400 means nothing in the batch was ingested, so every event is safe to resend.
+	 * Entities are processed FIFO:
+	 * <ul>
+	 *   <li>Delivered / dropped (i.e. {@link #processHit} returns {@code true}) → counted as resolved.</li>
+	 *   <li>Recoverable failure (returns {@code false}) → stop; return the resolved count so the
+	 *       queue can remove those entities and schedule a retry for the remainder.</li>
+	 * </ul>
+	 *
+	 * @param batchEntities the entities that made up the failed batch, in original queue order
+	 * @return {@link BatchOutcome} directing the queue how to advance
+	 */
+	private BatchOutcome explodeAndResend(@NonNull final List<DataEntity> batchEntities) {
+		Log.debug(LOG_TAG, LOG_SOURCE,
+				"Exploding batch of %d events to individual requests.", batchEntities.size());
+
+		int resolvedCount = 0;
+		for (final DataEntity entity : batchEntities) {
+			// Each entity is sent as a batch-of-1, which goes through the same terminal path
+			// (handles SUCCESS, DROP, and the terminal-400 case that fires the error callback).
+			final BatchOutcome outcome = processBatch(Collections.singletonList(entity));
+
+			switch (outcome.getKind()) {
+				case DONE:
+					resolvedCount++;
+					Log.trace(LOG_TAG, LOG_SOURCE,
+							"Explosion: event %d/%d resolved.", resolvedCount, batchEntities.size());
+					break;
+
+				case RETRY_BATCH:
+					// Recoverable failure — stop exploding. Leave this entity (and everything after)
+					// in the queue so the normal retry cycle handles them.
+					final int delay = outcome.getRetryAfterSeconds();
+					Log.debug(LOG_TAG, LOG_SOURCE,
+							"Explosion: event at position %d/%d needs retry in %d seconds; "
+									+ "%d preceding events resolved.",
+							resolvedCount + 1, batchEntities.size(), delay, resolvedCount);
+					if (resolvedCount > 0) {
+						return BatchOutcome.partialRemove(resolvedCount, delay);
+					}
+					return BatchOutcome.retryBatch(delay);
+
+				default:
+					// PARTIAL_REMOVE cannot occur for a size-1 processBatch call.
+					resolvedCount++;
+					break;
+			}
+		}
+
+		Log.debug(LOG_TAG, LOG_SOURCE,
+				"Explosion complete: all %d events resolved.", batchEntities.size());
+		return BatchOutcome.done();
+	}
+
+	/**
 	 * Send network requests out with the data encapsulated in {@link DataEntity}.
 	 * If configuration is null, the processing is paused.
 	 *
@@ -113,6 +404,22 @@ class EdgeHitProcessor implements HitProcessing {
 		}
 
 		processingResult.complete(hitCompleteResult);
+	}
+
+	/**
+	 * Delivers a terminal 400 error for the given {@code requestId}: processes the server error
+	 * body through the response handler (dispatching error events to waiting events) and then
+	 * fires completion (removing waiting state and unregistering callbacks).
+	 *
+	 * <p>Used for any single-event 400 — whether from {@link #processBatch} (batch-of-1) or from
+	 * {@link #sendNetworkRequest} (Consent/Reset paths).
+	 *
+	 * @param requestId  the Edge request ID whose waiting events should receive the error
+	 * @param errorBody  the JSON error body captured from the 400 response; may be null
+	 */
+	private void deliverTerminalBadRequest(final String requestId, final String errorBody) {
+		networkResponseHandler.processResponseOnError(errorBody, requestId);
+		networkResponseHandler.processResponseOnComplete(requestId);
 	}
 
 	/**
@@ -196,7 +503,15 @@ class EdgeHitProcessor implements HitProcessing {
 				entityRetryIntervalMapping.remove(entityId);
 			}
 
-			return true; // Hit sent successfully
+			// Consent/Reset events are always terminal. A 400 here is never exploded — deliver
+			// the real error body directly and fire completion so the caller sees it.
+			if (retryResult != null
+					&& retryResult.getNetworkRequestOutcome()
+						== EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400) {
+				deliverTerminalBadRequest(edgeHit.getRequestId(), retryResult.getResponseBody());
+			}
+
+			return true; // Hit complete (success, drop, or terminal 400)
 		} else {
 			if (
 				entityId != null &&

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeJson.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeJson.java
@@ -126,6 +126,7 @@ class EdgeJson {
 			static final String SEVERITY = "severity";
 			static final String STATUS = "status";
 			static final String TITLE = "title";
+			static final String DETAIL = "detail";
 			static final String EVENT_INDEX = "eventIndex";
 			static final String TYPE = "type";
 

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeNetworkService.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeNetworkService.java
@@ -162,6 +162,27 @@ class EdgeNetworkService {
 		final Map<String, String> requestHeaders,
 		final ResponseCallback responseCallback
 	) {
+		return doRequest(url, jsonRequest, requestHeaders, false, responseCallback);
+	}
+
+	/**
+	 * Same as {@link #doRequest(String, String, Map, ResponseCallback)}, with one additional
+	 * distinction: whether a 400 response is classified as {@link NetworkRequestOutcome#EXPLODE_400}
+	 * (only meaningful for a real multi-event batch, which the caller is prepared to explode into
+	 * individual resends) or treated as any other unrecoverable error code (single-event requests,
+	 * including exploded resends and Consent/Reset — identical to this method's behaviour before
+	 * batching existed).
+	 *
+	 * @param isBatchRequest true if {@code jsonRequest} carries more than one event and the caller
+	 *                       will explode a 400 into individual resends; false for single-event requests
+	 */
+	RetryResult doRequest(
+		final String url,
+		final String jsonRequest,
+		final Map<String, String> requestHeaders,
+		final boolean isBatchRequest,
+		final ResponseCallback responseCallback
+	) {
 		if (StringUtils.isNullOrEmpty(url)) {
 			Log.error(LOG_TAG, LOG_SOURCE, "Could not send request to a null url");
 
@@ -250,11 +271,11 @@ class EdgeNetworkService {
 				shouldStreamResponse ? konductorConfig.getLineFeed() : null,
 				responseCallback
 			);
-		} else if (connection.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
-			// 400 means nothing was ingested. If this is a batch, the caller will explode it to
+		} else if (isBatchRequest && connection.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
+			// 400 on a real batch means nothing was ingested and the caller will explode it to
 			// individual requests. Suppress handleError and onComplete here so events don't get
 			// phantom error/complete callbacks before the individual resends are attempted.
-			// Capture the body so terminal callers (batch-of-1) can deliver the real error.
+			// Capture the body so the caller can deliver the real error per exploded event, if needed.
 			Log.warning(
 				LOG_TAG,
 				LOG_SOURCE,
@@ -264,6 +285,9 @@ class EdgeNetworkService {
 			retryResult = new RetryResult(NetworkRequestOutcome.EXPLODE_400, 0);
 			retryResult.setResponseBody(readErrorBodyAsJson(connection.getErrorStream()));
 		} else {
+			// A single-event 400 (including an exploded resend) falls through here, identical to any
+			// other unrecoverable error code — same log line, same handleError→onError→onComplete flow
+			// as before batching existed.
 			Log.warning(
 				LOG_TAG,
 				LOG_SOURCE,

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeNetworkService.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeNetworkService.java
@@ -277,8 +277,8 @@ class EdgeNetworkService {
 		} else if (isBatchRequest && connection.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
 			// 400 on a real batch means nothing was ingested and the caller will explode it to
 			// individual requests. Suppress handleError and onComplete here so events don't get
-			// phantom error/complete callbacks before the individual resends are attempted.
-			// Capture the body so the caller can deliver the real error per exploded event, if needed.
+			// phantom error/complete callbacks before the individual resends are attempted; each
+			// exploded resend gets its own fresh error (if any) from its own single-event attempt.
 			Log.warning(
 				LOG_TAG,
 				LOG_SOURCE,
@@ -286,7 +286,6 @@ class EdgeNetworkService {
 				connection.getResponseMessage()
 			);
 			retryResult = new RetryResult(NetworkRequestOutcome.EXPLODE_400, 0);
-			retryResult.setResponseBody(readErrorBodyAsJson(connection.getErrorStream()));
 		} else {
 			// A single-event 400 (including an exploded resend) falls through here, identical to any
 			// other unrecoverable error code — same log line, same handleError→onError→onComplete flow
@@ -583,32 +582,6 @@ class EdgeNetworkService {
 			EdgeConstants.NetworkKeys.HEADER_VALUE_APPLICATION_JSON
 		);
 		return defaultHeaders;
-	}
-
-	/**
-	 * Reads the error body from {@code inputStream} and returns it as a JSON string.
-	 * Mirrors the parsing logic of {@link #handleError} but returns the result instead of
-	 * invoking a callback — used for capturing 400 bodies for terminal error delivery.
-	 *
-	 * @param inputStream the error stream from the HTTP connection, may be null
-	 * @return valid JSON string representing the error; never null
-	 */
-	String readErrorBodyAsJson(final InputStream inputStream) {
-		if (inputStream == null) {
-			return composeGenericErrorAsJson(null);
-		}
-
-		String responseStr = readInputStream(inputStream);
-		try {
-			if (responseStr != null) {
-				new JSONObject(responseStr); // validate JSON
-			} else {
-				responseStr = composeGenericErrorAsJson(null);
-			}
-		} catch (JSONException e) {
-			responseStr = composeGenericErrorAsJson(responseStr);
-		}
-		return responseStr;
 	}
 
 	/**

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeNetworkService.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeNetworkService.java
@@ -87,7 +87,7 @@ class EdgeNetworkService {
 		SUCCESS,
 		RETRY,
 		EXPLODE_400,
-		DROP
+		DROP,
 	}
 
 	interface ResponseCallback {
@@ -196,7 +196,10 @@ class EdgeNetworkService {
 		HttpConnecting connection = doConnect(url, jsonRequest, requestHeaders);
 
 		if (connection == null) {
-			final RetryResult retryResult = new RetryResult(NetworkRequestOutcome.RETRY, EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS);
+			final RetryResult retryResult = new RetryResult(
+				NetworkRequestOutcome.RETRY,
+				EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS
+			);
 			Log.debug(
 				LOG_TAG,
 				LOG_SOURCE,
@@ -303,9 +306,11 @@ class EdgeNetworkService {
 
 		// For EXPLODE_400, skip onComplete: the caller will re-register individual events under
 		// new request IDs and fire their own completions after explosion.
-		if (retryResult.getShouldRetry() == Retry.NO
-				&& retryResult.getNetworkRequestOutcome() != NetworkRequestOutcome.EXPLODE_400
-				&& responseCallback != null) {
+		if (
+			retryResult.getShouldRetry() == Retry.NO &&
+			retryResult.getNetworkRequestOutcome() != NetworkRequestOutcome.EXPLODE_400 &&
+			responseCallback != null
+		) {
 			responseCallback.onComplete();
 		}
 

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeNetworkService.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EdgeNetworkService.java
@@ -72,6 +72,24 @@ class EdgeNetworkService {
 		}
 	}
 
+	/**
+	 * Granular classification of a completed network attempt, used by batch processing to
+	 * decide the next queue action without re-inspecting HTTP codes.
+	 *
+	 * <ul>
+	 *   <li>{@link #SUCCESS}     — 2xx / 207: response callbacks already fired; remove batch.</li>
+	 *   <li>{@link #RETRY}       — recoverable (429 / 5xx / timeout): nothing ingested; retry batch.</li>
+	 *   <li>{@link #EXPLODE_400} — 400: nothing ingested; re-send each event individually.</li>
+	 *   <li>{@link #DROP}        — other non-recoverable (403, 404, 422 …): drop batch, error all.</li>
+	 * </ul>
+	 */
+	public enum NetworkRequestOutcome {
+		SUCCESS,
+		RETRY,
+		EXPLODE_400,
+		DROP
+	}
+
 	interface ResponseCallback {
 		/**
 		 * This method is called when the response was successfully fetched from the Adobe Experience Edge
@@ -151,13 +169,13 @@ class EdgeNetworkService {
 				responseCallback.onComplete();
 			}
 
-			return new RetryResult(Retry.NO);
+			return new RetryResult(NetworkRequestOutcome.DROP, 0);
 		}
 
 		HttpConnecting connection = doConnect(url, jsonRequest, requestHeaders);
 
 		if (connection == null) {
-			final RetryResult retryResult = new RetryResult(Retry.YES);
+			final RetryResult retryResult = new RetryResult(NetworkRequestOutcome.RETRY, EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS);
 			Log.debug(
 				LOG_TAG,
 				LOG_SOURCE,
@@ -167,7 +185,7 @@ class EdgeNetworkService {
 			return retryResult;
 		}
 
-		RetryResult retryResult = new RetryResult(Retry.NO);
+		RetryResult retryResult = new RetryResult(NetworkRequestOutcome.SUCCESS, 0);
 
 		if (connection.getResponseCode() == HttpURLConnection.HTTP_OK) {
 			Log.debug(
@@ -195,7 +213,8 @@ class EdgeNetworkService {
 				connection.getResponseMessage()
 			);
 		} else if (recoverableNetworkErrorCodes.contains(connection.getResponseCode())) {
-			retryResult = new RetryResult(Retry.YES, computeRetryInterval(connection));
+			final int retryInterval = computeRetryInterval(connection);
+			retryResult = new RetryResult(NetworkRequestOutcome.RETRY, retryInterval);
 
 			if (connection.getResponseCode() == -1) {
 				Log.debug(
@@ -231,6 +250,19 @@ class EdgeNetworkService {
 				shouldStreamResponse ? konductorConfig.getLineFeed() : null,
 				responseCallback
 			);
+		} else if (connection.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
+			// 400 means nothing was ingested. If this is a batch, the caller will explode it to
+			// individual requests. Suppress handleError and onComplete here so events don't get
+			// phantom error/complete callbacks before the individual resends are attempted.
+			// Capture the body so terminal callers (batch-of-1) can deliver the real error.
+			Log.warning(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Connection to Experience Edge returned 400 Bad Request. Response message: %s. Nothing ingested.",
+				connection.getResponseMessage()
+			);
+			retryResult = new RetryResult(NetworkRequestOutcome.EXPLODE_400, 0);
+			retryResult.setResponseBody(readErrorBodyAsJson(connection.getErrorStream()));
 		} else {
 			Log.warning(
 				LOG_TAG,
@@ -240,11 +272,16 @@ class EdgeNetworkService {
 				connection.getResponseMessage()
 			);
 			handleError(connection.getErrorStream(), responseCallback);
+			retryResult = new RetryResult(NetworkRequestOutcome.DROP, 0);
 		}
 
 		connection.close();
 
-		if (retryResult.getShouldRetry() == Retry.NO && responseCallback != null) {
+		// For EXPLODE_400, skip onComplete: the caller will re-register individual events under
+		// new request IDs and fire their own completions after explosion.
+		if (retryResult.getShouldRetry() == Retry.NO
+				&& retryResult.getNetworkRequestOutcome() != NetworkRequestOutcome.EXPLODE_400
+				&& responseCallback != null) {
 			responseCallback.onComplete();
 		}
 
@@ -517,6 +554,32 @@ class EdgeNetworkService {
 			EdgeConstants.NetworkKeys.HEADER_VALUE_APPLICATION_JSON
 		);
 		return defaultHeaders;
+	}
+
+	/**
+	 * Reads the error body from {@code inputStream} and returns it as a JSON string.
+	 * Mirrors the parsing logic of {@link #handleError} but returns the result instead of
+	 * invoking a callback — used for capturing 400 bodies for terminal error delivery.
+	 *
+	 * @param inputStream the error stream from the HTTP connection, may be null
+	 * @return valid JSON string representing the error; never null
+	 */
+	String readErrorBodyAsJson(final InputStream inputStream) {
+		if (inputStream == null) {
+			return composeGenericErrorAsJson(null);
+		}
+
+		String responseStr = readInputStream(inputStream);
+		try {
+			if (responseStr != null) {
+				new JSONObject(responseStr); // validate JSON
+			} else {
+				responseStr = composeGenericErrorAsJson(null);
+			}
+		} catch (JSONException e) {
+			responseStr = composeGenericErrorAsJson(responseStr);
+		}
+		return responseStr;
 	}
 
 	/**

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EventUtils.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EventUtils.java
@@ -85,44 +85,20 @@ final class EventUtils {
 		// Bundled batching config is a per-key fallback only: consulted for a given key solely when
 		// that key is absent from the Configuration shared state (i.e. not set programmatically, and
 		// not delivered by a remote/Launch-published configuration). Any value present in the
-		// Configuration shared state always wins over the bundled file for that same key.
+		// Configuration shared state always wins over the bundled file for that same key. Values are
+		// copied raw; consumers coerce via DataReader (optBoolean/optStringList) at read time.
 		final Map<String, Object> bundledBatchingConfig = EdgeBundledBatchingConfig.get();
+		final String[] batchingConfigKeys = new String[] {
+			EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED,
+			EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST,
+		};
 
-		if (configSharedState != null && configSharedState.containsKey(EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED)) {
-			edgeConfig.put(
-				EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED,
-				DataReader.optBoolean(configSharedState, EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED, false)
-			);
-		} else if (bundledBatchingConfig.containsKey(EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED)) {
-			edgeConfig.put(
-				EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED,
-				DataReader.optBoolean(bundledBatchingConfig, EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED, false)
-			);
-		}
-
-		if (
-			configSharedState != null &&
-			configSharedState.containsKey(EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST)
-		) {
-			edgeConfig.put(
-				EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST,
-				DataReader.optStringList(
-					configSharedState,
-					EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST,
-					null
-				)
-			);
-		} else if (
-			bundledBatchingConfig.containsKey(EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST)
-		) {
-			edgeConfig.put(
-				EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST,
-				DataReader.optStringList(
-					bundledBatchingConfig,
-					EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST,
-					null
-				)
-			);
+		for (final String batchingKey : batchingConfigKeys) {
+			if (configSharedState != null && configSharedState.containsKey(batchingKey)) {
+				edgeConfig.put(batchingKey, configSharedState.get(batchingKey));
+			} else if (bundledBatchingConfig.containsKey(batchingKey)) {
+				edgeConfig.put(batchingKey, bundledBatchingConfig.get(batchingKey));
+			}
 		}
 
 		return edgeConfig;

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EventUtils.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EventUtils.java
@@ -91,6 +91,7 @@ final class EventUtils {
 		final String[] batchingConfigKeys = new String[] {
 			EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED,
 			EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST,
+			EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE,
 		};
 
 		for (final String batchingKey : batchingConfigKeys) {

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EventUtils.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EventUtils.java
@@ -82,6 +82,13 @@ final class EventUtils {
 			MapUtils.putIfNotEmpty(edgeConfig, configKey, configValue);
 		}
 
+		if (configSharedState != null && configSharedState.containsKey(EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED)) {
+			edgeConfig.put(
+				EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED,
+				DataReader.optBoolean(configSharedState, EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED, false)
+			);
+		}
+
 		return edgeConfig;
 	}
 

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/EventUtils.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/EventUtils.java
@@ -82,10 +82,46 @@ final class EventUtils {
 			MapUtils.putIfNotEmpty(edgeConfig, configKey, configValue);
 		}
 
+		// Bundled batching config is a per-key fallback only: consulted for a given key solely when
+		// that key is absent from the Configuration shared state (i.e. not set programmatically, and
+		// not delivered by a remote/Launch-published configuration). Any value present in the
+		// Configuration shared state always wins over the bundled file for that same key.
+		final Map<String, Object> bundledBatchingConfig = EdgeBundledBatchingConfig.get();
+
 		if (configSharedState != null && configSharedState.containsKey(EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED)) {
 			edgeConfig.put(
 				EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED,
 				DataReader.optBoolean(configSharedState, EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED, false)
+			);
+		} else if (bundledBatchingConfig.containsKey(EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED)) {
+			edgeConfig.put(
+				EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED,
+				DataReader.optBoolean(bundledBatchingConfig, EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED, false)
+			);
+		}
+
+		if (
+			configSharedState != null &&
+			configSharedState.containsKey(EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST)
+		) {
+			edgeConfig.put(
+				EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST,
+				DataReader.optStringList(
+					configSharedState,
+					EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST,
+					null
+				)
+			);
+		} else if (
+			bundledBatchingConfig.containsKey(EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST)
+		) {
+			edgeConfig.put(
+				EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST,
+				DataReader.optStringList(
+					bundledBatchingConfig,
+					EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST,
+					null
+				)
 			);
 		}
 

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
@@ -385,7 +385,59 @@ class NetworkResponseHandler {
 				}
 			}
 
-			String requestEventId = extractRequestEventId(handle.getEventIndex(), requestId);
+			// Resolve the originating event for this handle using the routing policy:
+			// - Indexed handle  → route to the specific event at that position.
+			// - No eventIndex, 1 waiting event → unambiguous; route to it (backward compat).
+			// - No eventIndex, global handle type (state:store / locationHint:result)
+			//   → broadcast: apply side-effect globally, dispatch with null parentId.
+			// - No eventIndex, other type, batch > 1 → log and skip per-event attribution.
+			final String requestEventId;
+			final int handleEventIndex = handle.getEventIndex();
+
+			if (handleEventIndex != EdgeEventHandle.ABSENT_EVENT_INDEX) {
+				requestEventId = extractRequestEventId(handleEventIndex, requestId);
+				Log.trace(
+					LOG_TAG,
+					LOG_SOURCE,
+					"Handle type '%s' eventIndex=%d → event id: %s (requestId: %s)",
+					handle.getType(),
+					handleEventIndex,
+					requestEventId,
+					requestId
+				);
+			} else {
+				final List<String> waitingIds = getWaitingEvents(requestId);
+				if (waitingIds.size() == 1) {
+					requestEventId = waitingIds.get(0);
+					Log.trace(
+						LOG_TAG,
+						LOG_SOURCE,
+						"Handle type '%s' has no eventIndex; single-event request → routed to event id: %s (requestId: %s)",
+						handle.getType(),
+						requestEventId,
+						requestId
+					);
+				} else if (isGlobalHandleType(handle.getType())) {
+					requestEventId = null;
+					Log.trace(
+						LOG_TAG,
+						LOG_SOURCE,
+						"Handle type '%s' is a global handle (no eventIndex) → broadcast with null parentId (requestId: %s)",
+						handle.getType(),
+						requestId
+					);
+				} else {
+					requestEventId = null;
+					Log.warning(
+						LOG_TAG,
+						LOG_SOURCE,
+						"Handle type '%s' has no eventIndex in a batch of %d events and is not a known global type — skipping per-event attribution (requestId: %s)",
+						handle.getType(),
+						waitingIds.size(),
+						requestId
+					);
+				}
+			}
 
 			// Dispatched events add the event and request IDs to the data, so use a copy of the data
 			// so the IDs are not in the data when invoking the response callback
@@ -448,13 +500,35 @@ class NetworkResponseHandler {
 	 * @return the event ID for which this event handle was received, or null if not found
 	 */
 	private String extractRequestEventId(final int eventIndex, final String requestId) {
-		List<String> requestEventIdsList = getWaitingEvents(requestId);
+		final List<String> requestEventIdsList = getWaitingEvents(requestId);
 
 		if (eventIndex >= 0 && eventIndex < requestEventIdsList.size()) {
 			return requestEventIdsList.get(eventIndex);
 		}
 
+		if (eventIndex != EdgeEventHandle.ABSENT_EVENT_INDEX) {
+			// Diagnostic only — logged at trace level to avoid polluting the warning channel
+			// (matches iOS, which silently returns nil for an out-of-range index).
+			Log.trace(
+				LOG_TAG,
+				LOG_SOURCE,
+				"eventIndex %d is out of range for waiting events list of size %d (requestId: %s)",
+				eventIndex,
+				requestEventIdsList.size(),
+				requestId
+			);
+		}
+
 		return null;
+	}
+
+	/**
+	 * Returns true for handle types that are session/batch scoped and carry no {@code eventIndex}
+	 * by design — these are broadcast globally rather than attributed to a specific event.
+	 */
+	private boolean isGlobalHandleType(final String handleType) {
+		return EdgeJson.Response.EventHandle.Store.TYPE.equals(handleType) ||
+			EdgeJson.Response.EventHandle.LocationHint.TYPE.equals(handleType);
 	}
 
 	private void dispatchEventResponse(
@@ -553,12 +627,19 @@ class NetworkResponseHandler {
 	 */
 	private void dispatchEventErrors(final JSONArray errorsArray, final boolean isError, final String requestId) {
 		if (JSONUtils.isNullOrEmpty(errorsArray)) {
-			Log.trace(LOG_TAG, LOG_SOURCE, "Received null/empty errors array, nothing to handle");
+			Log.trace(LOG_TAG, LOG_SOURCE, "Received null/empty %s array, nothing to handle", isError ? "errors" : "warnings");
 			return;
 		}
 
 		int size = errorsArray.length();
-		Log.trace(LOG_TAG, LOG_SOURCE, "Processing %d error(s) for request id: %s", size, requestId);
+		Log.trace(
+			LOG_TAG,
+			LOG_SOURCE,
+			"Processing %d %s(s) for request id: %s",
+			size,
+			isError ? "error" : "warning",
+			requestId
+		);
 
 		for (int i = 0; i < size; i++) {
 			JSONObject currentError = null;
@@ -566,14 +647,13 @@ class NetworkResponseHandler {
 
 			try {
 				currentError = errorsArray.getJSONObject(i);
-
-				// Convert json object to Map<String, Object> to be able to pass it as Event data
 				eventDataResponse = JSONUtils.toMap(currentError);
 			} catch (JSONException e) {
 				Log.trace(
 					LOG_TAG,
 					LOG_SOURCE,
-					"Event error with index %d was not processed due to JSONException: %s",
+					"%s entry at index %d could not be parsed (JSONException): %s",
+					isError ? "Error" : "Warning",
 					i,
 					e.getLocalizedMessage()
 				);
@@ -582,24 +662,78 @@ class NetworkResponseHandler {
 				continue;
 			}
 
-			// if eventIndex not found in the response, it fallbacks to 0 as per Edge Network spec
-			Map<String, Object> report = DataReader.optTypedMap(
+			// Read eventIndex from report — treat absent as ABSENT_EVENT_INDEX, not 0.
+			final Map<String, Object> report = DataReader.optTypedMap(
 				Object.class,
 				eventDataResponse,
 				EdgeJson.Response.EventHandle.REPORT,
 				null
 			);
-			int eventIndex = DataReader.optInt(report, EdgeJson.Response.EventHandle.EVENT_INDEX, 0);
-			String eventId = extractRequestEventId(eventIndex, requestId);
+			final boolean hasEventIndex = report != null && report.containsKey(EdgeJson.Response.EventHandle.EVENT_INDEX);
+			final int eventIndex = hasEventIndex
+					? DataReader.optInt(report, EdgeJson.Response.EventHandle.EVENT_INDEX, EdgeEventHandle.ABSENT_EVENT_INDEX)
+					: EdgeEventHandle.ABSENT_EVENT_INDEX;
 
 			logErrorMessage(currentError, isError, requestId);
 
-			// do not include eventIndex in the response event
-			removeEventIndexFromReport(eventDataResponse);
+			final EdgeEventError edgeEventError = isError ? buildEdgeEventError(eventDataResponse) : null;
 
-			// set eventRequestId and edge requestId on the response event and dispatch data
-			addEventAndRequestIdToData(eventDataResponse, requestId, eventId);
-			dispatchResponse(eventDataResponse, eventId, true, null);
+			// Routing policy (mirrors processEventHandles):
+			// - Indexed error/warning  → route to the specific event.
+			// - No eventIndex, 1 waiting event → unambiguous; route to it.
+			// - No eventIndex, batch > 1 → dispatch to ALL waiting events.
+			if (eventIndex != EdgeEventHandle.ABSENT_EVENT_INDEX) {
+				final String eventId = extractRequestEventId(eventIndex, requestId);
+				Log.trace(
+					LOG_TAG,
+					LOG_SOURCE,
+					"%s eventIndex=%d → event id: %s (requestId: %s)",
+					isError ? "Error" : "Warning",
+					eventIndex,
+					eventId,
+					requestId
+				);
+				final Map<String, Object> copy = new HashMap<>(eventDataResponse);
+				removeEventIndexFromReport(copy);
+				addEventAndRequestIdToData(copy, requestId, eventId);
+				// Both errors and warnings dispatch on the error-response channel (iOS parity);
+				// the isError flag only controls log level and onError delivery, not the channel.
+				dispatchResponse(copy, eventId, true, null);
+				if (edgeEventError != null && !StringUtils.isNullOrEmpty(eventId)) {
+					CompletionCallbacksManager.getInstance().eventErrorReceived(eventId, edgeEventError);
+				}
+			} else {
+				final List<String> waitingIds = getWaitingEvents(requestId);
+				if (waitingIds.isEmpty()) {
+					// No registered events for this requestId — dispatch as broadcast (null parentId).
+					// This preserves backward compatibility for callers that do not register waiting events.
+					final Map<String, Object> copy = new HashMap<>(eventDataResponse);
+					removeEventIndexFromReport(copy);
+					addEventAndRequestIdToData(copy, requestId, null);
+					dispatchResponse(copy, null, true, null);
+				} else {
+					// Deliver one error event per waiting event. For N==1 this naturally routes to
+					// event[0], preserving the single-event contract. For N>1 every caller learns
+					// their event failed (iOS parity).
+					Log.trace(
+						LOG_TAG,
+						LOG_SOURCE,
+						"%s has no eventIndex → dispatching to all %d waiting event(s) (requestId: %s)",
+						isError ? "Error" : "Warning",
+						waitingIds.size(),
+						requestId
+					);
+					for (final String eventId : waitingIds) {
+						final Map<String, Object> copy = new HashMap<>(eventDataResponse);
+						removeEventIndexFromReport(copy);
+						addEventAndRequestIdToData(copy, requestId, eventId);
+						dispatchResponse(copy, eventId, true, null);
+						if (edgeEventError != null) {
+							CompletionCallbacksManager.getInstance().eventErrorReceived(eventId, edgeEventError);
+						}
+					}
+				}
+			}
 		}
 	}
 
@@ -656,6 +790,18 @@ class NetworkResponseHandler {
 				String.format("Received event error for request id (%s), error details:\n %s", requestId, errorToLog)
 			);
 		}
+	}
+
+	/**
+	 * Builds an {@link EdgeEventError} from the error/warning data map returned by the server.
+	 * Fields not present in the map default to empty string / 0.
+	 */
+	private EdgeEventError buildEdgeEventError(final Map<String, Object> errorData) {
+		final String type = DataReader.optString(errorData, EdgeJson.Response.Error.TYPE, "");
+		final int status = DataReader.optInt(errorData, EdgeJson.Response.Error.STATUS, 0);
+		final String title = DataReader.optString(errorData, EdgeJson.Response.Error.TITLE, "");
+		final String detail = DataReader.optString(errorData, EdgeJson.Response.Error.DETAIL, null);
+		return new EdgeEventError(type, status, title, detail);
 	}
 
 	/**

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
@@ -13,7 +13,6 @@ package com.adobe.marketing.mobile;
 
 import static com.adobe.marketing.mobile.EdgeConstants.LOG_TAG;
 
-import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.NamedCollection;
 import com.adobe.marketing.mobile.util.DataReader;
@@ -41,29 +40,14 @@ class NetworkResponseHandler {
 
 	private static final String LOG_SOURCE = "NetworkResponseHandler";
 
-	/**
-	 * Behaviour switch for early per-event completion (index-advance). Defined here, alongside the
-	 * completion logic it governs, rather than as a global config/constant — there is intentionally no
-	 * runtime/Configuration API to change it yet.
-	 *
-	 * <p>When {@code true} (default), a batched event's completion fires as soon as a response fragment
-	 * for a higher {@code eventIndex} is observed (all lower-index events are then known complete),
-	 * instead of waiting for the whole batch's stream to close. The highest index and anything still
-	 * pending complete at stream close, exactly as before. When {@code false}, the behaviour is
-	 * identical to the historical "complete the whole batch at stream close" path.
-	 *
-	 * <p>Only relevant to multi-event batched responses on the streaming (SUCCESS/207) path; single
-	 * events, consent, batch-of-1, RETRY and EXPLODE_400 are unaffected either way.
-	 */
-	@VisibleForTesting
-	static boolean earlyPerEventCompletionEnabled = true;
-
 	// the order of the request events matter for matching them with the response events
 	private final ConcurrentMap<String, List<Event>> sentEventsWaitingResponse;
-	// early-completion progress, keyed by requestId: highest eventIndex observed in the response so far
-	private final ConcurrentMap<String, Integer> highestObservedIndex = new ConcurrentHashMap<>();
-	// early-completion progress, keyed by requestId: number of leading events already completed
-	// (monotonic; guarantees each event completes exactly once)
+	// Early per-event completion progress, keyed by requestId: number of leading events already
+	// completed (monotonic; guarantees each event completes exactly once). A batched event's completion
+	// fires as soon as a response fragment for a higher eventIndex is observed — all lower-index events
+	// are then known complete — instead of waiting for the whole batch's stream to close. The highest
+	// index and anything still pending complete at stream close. Single events / consent / batch-of-1
+	// simply complete at stream close, since no higher index is ever observed to advance the boundary.
 	private final ConcurrentMap<String, Integer> nextCompletionIndex = new ConcurrentHashMap<>();
 	private final Object mutex = new Object();
 	private final NamedCollection namedCollection;
@@ -143,7 +127,6 @@ class NetworkResponseHandler {
 		}
 
 		synchronized (mutex) {
-			highestObservedIndex.remove(requestId);
 			nextCompletionIndex.remove(requestId);
 			return sentEventsWaitingResponse.remove(requestId);
 		}
@@ -246,14 +229,10 @@ class NetworkResponseHandler {
 			// ok, ignore if there are no warnings
 		}
 
-		// Early per-event completion: now that this fragment's handles/errors/warnings are all
-		// processed and accumulated, complete every waiting event whose index is strictly below the
-		// highest index observed so far — observing index M means events 0..M-1 have no more data
-		// coming (Konductor streams fragments grouped by event, in index order). The highest index
-		// (and anything still pending) completes at stream close in processResponseOnComplete.
-		if (earlyPerEventCompletionEnabled) {
-			sweepCompletions(requestId, highestObservedIndexFor(requestId));
-		}
+		// Early per-event completion happens inline as each handle/error/warning is processed above:
+		// observing eventIndex M sweeps completions for events 0..M-1 (see processEventHandles /
+		// dispatchEventErrors). The highest index seen (and anything still pending) completes at stream
+		// close in processResponseOnComplete.
 	}
 
 	/**
@@ -319,7 +298,7 @@ class NetworkResponseHandler {
 	 */
 	void processResponseOnComplete(final String requestId) {
 		// Capture progress BEFORE removeWaitingEvents clears the per-request state.
-		final int alreadyCompleted = earlyPerEventCompletionEnabled ? completedCountFor(requestId) : 0;
+		final int alreadyCompleted = completedCountFor(requestId);
 
 		// removeWaitingEvents returns the full ordered event list for this request and clears state.
 		List<Event> removedWaitingEvents = removeWaitingEvents(requestId);
@@ -328,24 +307,18 @@ class NetworkResponseHandler {
 		}
 
 		// Complete everything not already early-completed (the highest index plus anything still
-		// pending). When early completion is off, alreadyCompleted is 0 → the whole batch completes
-		// here, identical to the historical stream-close behaviour.
+		// pending). For single events / consent nothing was early-completed → the whole request
+		// completes here at stream close.
 		for (int i = alreadyCompleted; i < removedWaitingEvents.size(); i++) {
 			completeEvent(requestId, removedWaitingEvents.get(i));
 		}
 	}
 
 	/**
-	 * @return the number of leading events already early-completed for {@code requestId} (0 if none —
-	 * including when the early-completion progress state is unavailable, e.g. an isolated unit test
-	 * that mocks this handler and invokes the real method with uninitialized fields).
+	 * @return the number of leading events already early-completed for {@code requestId}, or 0 if none.
 	 */
 	private int completedCountFor(final String requestId) {
-		final ConcurrentMap<String, Integer> progress = nextCompletionIndex;
-		if (progress == null) {
-			return 0;
-		}
-		final Integer completed = progress.get(requestId);
+		final Integer completed = nextCompletionIndex.get(requestId);
 		return completed == null ? 0 : completed;
 	}
 
@@ -381,61 +354,18 @@ class NetworkResponseHandler {
 	}
 
 	/**
-	 * Records the highest indexed {@code eventIndex} observed so far for {@code requestId}, used to
-	 * drive early per-event completion. No-op when early completion is disabled or the index is not a
-	 * real per-event index ({@link EdgeEventHandle#ABSENT_EVENT_INDEX}, i.e. global handles / no-index
-	 * broadcast errors — those must never advance completion).
-	 *
-	 * <p>If an index arrives that is lower than the completion boundary already reached, that violates
-	 * the assumed grouping (data for an event that was already completed); it is logged at WARNING for
-	 * investigation and otherwise ignored (the boundary is never moved backwards, so no event is
-	 * completed twice).
-	 *
-	 * @param requestId the batch request id
-	 * @param index the eventIndex observed on a handle/error/warning fragment
-	 */
-	private void recordObservedIndex(final String requestId, final int index) {
-		if (!earlyPerEventCompletionEnabled || index < 0) {
-			return;
-		}
-
-		synchronized (mutex) {
-			final Integer completed = nextCompletionIndex.get(requestId);
-			if (completed != null && index < completed) {
-				Log.warning(
-					LOG_TAG,
-					LOG_SOURCE,
-					"Unexpected response ordering: eventIndex %d arrived for request id (%s) after events through index %d were already completed. Not re-completing; investigate response grouping/ordering.",
-					index,
-					requestId,
-					completed - 1
-				);
-				return;
-			}
-
-			final Integer current = highestObservedIndex.get(requestId);
-			if (current == null || index > current) {
-				highestObservedIndex.put(requestId, index);
-			}
-		}
-	}
-
-	/**
-	 * @return the highest indexed {@code eventIndex} observed so far for {@code requestId}, or -1 if
-	 * none has been observed.
-	 */
-	private int highestObservedIndexFor(final String requestId) {
-		synchronized (mutex) {
-			final Integer value = highestObservedIndex.get(requestId);
-			return value == null ? -1 : value;
-		}
-	}
-
-	/**
 	 * Completes every waiting event for {@code requestId} whose position is at or after the current
-	 * completion boundary and strictly below {@code exclusiveUpperBound}, advancing the boundary so
-	 * each event completes exactly once. Events to complete are collected under {@code mutex} and the
-	 * actual completion (which dispatches events) is performed outside the lock.
+	 * completion boundary ({@code nextCompletionIndex}) and strictly below {@code exclusiveUpperBound},
+	 * advancing the boundary so each event completes exactly once. Called with a handle/error/warning's
+	 * {@code eventIndex}: observing index M means events 0..M-1 have no more data coming (Konductor
+	 * streams fragments grouped by event, in index order), so they can complete.
+	 *
+	 * <p>If {@code exclusiveUpperBound} is below the boundary already reached, a lower index arrived
+	 * after those events were completed — this violates the assumed grouping/ordering; it is logged at
+	 * WARNING and ignored (the boundary is never moved backwards, so no event completes twice).
+	 *
+	 * <p>Events to complete are collected under {@code mutex}; the actual completion (which dispatches
+	 * events) is performed outside the lock.
 	 *
 	 * @param requestId the batch request id
 	 * @param exclusiveUpperBound complete events with index in {@code [nextCompletionIndex,
@@ -449,6 +379,17 @@ class NetworkResponseHandler {
 				return;
 			}
 			int next = nextCompletionIndex.containsKey(requestId) ? nextCompletionIndex.get(requestId) : 0;
+			if (exclusiveUpperBound < next) {
+				Log.warning(
+					LOG_TAG,
+					LOG_SOURCE,
+					"Unexpected response ordering: eventIndex %d arrived for request id (%s) after events through index %d were already completed. Not re-completing; investigate response grouping/ordering.",
+					exclusiveUpperBound,
+					requestId,
+					next - 1
+				);
+				return;
+			}
 			final int limit = Math.min(exclusiveUpperBound, events.size());
 			while (next < limit) {
 				toComplete.add(events.get(next));
@@ -590,16 +531,13 @@ class NetworkResponseHandler {
 				}
 			}
 
-			// Track the highest per-event index seen, to drive early per-event completion. Global
-			// handles (ABSENT_EVENT_INDEX) do not advance completion.
-			recordObservedIndex(requestId, handleEventIndex);
-
 			// Complete any lower-indexed events still pending BEFORE dispatching this handle's data.
 			// Observing this handle's index means every lower index has no more data coming, so their
 			// completions (and whatever they read from downstream shared state, e.g. a listener's own
 			// in-progress accumulator) must fire before this handle is dispatched — not after, which
-			// would let this handle's data land ahead of a still-pending sibling's completion.
-			if (earlyPerEventCompletionEnabled && handleEventIndex != EdgeEventHandle.ABSENT_EVENT_INDEX) {
+			// would let this handle's data land ahead of a still-pending sibling's completion. Global
+			// handles (ABSENT_EVENT_INDEX) carry no index and do not advance completion.
+			if (handleEventIndex != EdgeEventHandle.ABSENT_EVENT_INDEX) {
 				sweepCompletions(requestId, handleEventIndex);
 			}
 
@@ -838,13 +776,10 @@ class NetworkResponseHandler {
 					? DataReader.optInt(report, EdgeJson.Response.EventHandle.EVENT_INDEX, EdgeEventHandle.ABSENT_EVENT_INDEX)
 					: EdgeEventHandle.ABSENT_EVENT_INDEX;
 
-			// Track the highest per-event index seen, to drive early per-event completion. No-index
-			// (root/broadcast) errors do not advance completion.
-			recordObservedIndex(requestId, eventIndex);
-
 			// Complete any lower-indexed events still pending BEFORE dispatching this error's data —
 			// same ordering guarantee as processEventHandles, applied to the error/warning channel.
-			if (earlyPerEventCompletionEnabled && eventIndex != EdgeEventHandle.ABSENT_EVENT_INDEX) {
+			// No-index (root/broadcast) errors carry no index and do not advance completion.
+			if (eventIndex != EdgeEventHandle.ABSENT_EVENT_INDEX) {
 				sweepCompletions(requestId, eventIndex);
 			}
 
@@ -879,23 +814,21 @@ class NetworkResponseHandler {
 			} else {
 				// A no-eventIndex error/warning applies to the whole request. Per the Konductor team,
 				// a root-level error means the whole batch failed atomically — it should not arrive
-				// after events already streamed successful per-event data. If early completion is on and
-				// some events already completed, flag it: those events did not receive this error.
-				if (earlyPerEventCompletionEnabled) {
-					final Integer completed;
-					synchronized (mutex) {
-						completed = nextCompletionIndex.get(requestId);
-					}
-					if (completed != null && completed > 0) {
-						Log.warning(
-							LOG_TAG,
-							LOG_SOURCE,
-							"Received a no-eventIndex %s for request id (%s) after %d event(s) were already early-completed; those events did not receive it. Root-level errors are expected only when the whole batch fails — investigate.",
-							isError ? "error" : "warning",
-							requestId,
-							completed
-						);
-					}
+				// after events already streamed successful per-event data. If some events already
+				// early-completed, flag it: those events did not receive this error.
+				final Integer completed;
+				synchronized (mutex) {
+					completed = nextCompletionIndex.get(requestId);
+				}
+				if (completed != null && completed > 0) {
+					Log.warning(
+						LOG_TAG,
+						LOG_SOURCE,
+						"Received a no-eventIndex %s for request id (%s) after %d event(s) were already early-completed; those events did not receive it. Root-level errors are expected only when the whole batch fails — investigate.",
+						isError ? "error" : "warning",
+						requestId,
+						completed
+					);
 				}
 
 				final List<String> waitingIds = getWaitingEvents(requestId);

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
@@ -13,6 +13,7 @@ package com.adobe.marketing.mobile;
 
 import static com.adobe.marketing.mobile.EdgeConstants.LOG_TAG;
 
+import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.NamedCollection;
 import com.adobe.marketing.mobile.util.DataReader;
@@ -40,8 +41,30 @@ class NetworkResponseHandler {
 
 	private static final String LOG_SOURCE = "NetworkResponseHandler";
 
+	/**
+	 * Behaviour switch for early per-event completion (index-advance). Defined here, alongside the
+	 * completion logic it governs, rather than as a global config/constant — there is intentionally no
+	 * runtime/Configuration API to change it yet.
+	 *
+	 * <p>When {@code true} (default), a batched event's completion fires as soon as a response fragment
+	 * for a higher {@code eventIndex} is observed (all lower-index events are then known complete),
+	 * instead of waiting for the whole batch's stream to close. The highest index and anything still
+	 * pending complete at stream close, exactly as before. When {@code false}, the behaviour is
+	 * identical to the historical "complete the whole batch at stream close" path.
+	 *
+	 * <p>Only relevant to multi-event batched responses on the streaming (SUCCESS/207) path; single
+	 * events, consent, batch-of-1, RETRY and EXPLODE_400 are unaffected either way.
+	 */
+	@VisibleForTesting
+	static boolean earlyPerEventCompletionEnabled = true;
+
 	// the order of the request events matter for matching them with the response events
 	private final ConcurrentMap<String, List<Event>> sentEventsWaitingResponse;
+	// early-completion progress, keyed by requestId: highest eventIndex observed in the response so far
+	private final ConcurrentMap<String, Integer> highestObservedIndex = new ConcurrentHashMap<>();
+	// early-completion progress, keyed by requestId: number of leading events already completed
+	// (monotonic; guarantees each event completes exactly once)
+	private final ConcurrentMap<String, Integer> nextCompletionIndex = new ConcurrentHashMap<>();
 	private final Object mutex = new Object();
 	private final NamedCollection namedCollection;
 	private final EdgeStateCallback edgeStateCallback;
@@ -120,6 +143,8 @@ class NetworkResponseHandler {
 		}
 
 		synchronized (mutex) {
+			highestObservedIndex.remove(requestId);
+			nextCompletionIndex.remove(requestId);
 			return sentEventsWaitingResponse.remove(requestId);
 		}
 	}
@@ -220,6 +245,15 @@ class NetworkResponseHandler {
 		} catch (JSONException e) {
 			// ok, ignore if there are no warnings
 		}
+
+		// Early per-event completion: now that this fragment's handles/errors/warnings are all
+		// processed and accumulated, complete every waiting event whose index is strictly below the
+		// highest index observed so far — observing index M means events 0..M-1 have no more data
+		// coming (Konductor streams fragments grouped by event, in index order). The highest index
+		// (and anything still pending) completes at stream close in processResponseOnComplete.
+		if (earlyPerEventCompletionEnabled) {
+			sweepCompletions(requestId, highestObservedIndexFor(requestId));
+		}
 	}
 
 	/**
@@ -284,30 +318,147 @@ class NetworkResponseHandler {
 	 * @param requestId the request id used to identify the request events
 	 */
 	void processResponseOnComplete(final String requestId) {
+		// Capture progress BEFORE removeWaitingEvents clears the per-request state.
+		final int alreadyCompleted = earlyPerEventCompletionEnabled ? completedCountFor(requestId) : 0;
+
+		// removeWaitingEvents returns the full ordered event list for this request and clears state.
 		List<Event> removedWaitingEvents = removeWaitingEvents(requestId);
+		if (removedWaitingEvents == null) {
+			return;
+		}
 
-		// unregister currently known completion callbacks
-		if (removedWaitingEvents != null) {
-			for (Event event : removedWaitingEvents) {
-				CompletionCallbacksManager.getInstance().unregisterCallback(event.getUniqueIdentifier());
+		// Complete everything not already early-completed (the highest index plus anything still
+		// pending). When early completion is off, alreadyCompleted is 0 → the whole batch completes
+		// here, identical to the historical stream-close behaviour.
+		for (int i = alreadyCompleted; i < removedWaitingEvents.size(); i++) {
+			completeEvent(requestId, removedWaitingEvents.get(i));
+		}
+	}
 
-				if (sendCompletionRequested(event)) {
-					// send completion event
-					Map<String, Object> eventData = new HashMap<>();
-					addEventAndRequestIdToData(eventData, requestId, null);
+	/**
+	 * @return the number of leading events already early-completed for {@code requestId} (0 if none —
+	 * including when the early-completion progress state is unavailable, e.g. an isolated unit test
+	 * that mocks this handler and invokes the real method with uninitialized fields).
+	 */
+	private int completedCountFor(final String requestId) {
+		final ConcurrentMap<String, Integer> progress = nextCompletionIndex;
+		if (progress == null) {
+			return 0;
+		}
+		final Integer completed = progress.get(requestId);
+		return completed == null ? 0 : completed;
+	}
 
-					Event responseEvent = new Event.Builder(
-						EdgeConstants.EventName.CONTENT_COMPLETE,
-						EventType.EDGE,
-						EventSource.CONTENT_COMPLETE
-					)
-						.setEventData(eventData)
-						.inResponseToEvent(event)
-						.build();
+	/**
+	 * Completes a single waiting {@code event}: unregisters its response callback (firing the
+	 * internal {@link EdgeCallback} onComplete/onError with the handles/errors accumulated for it) and,
+	 * if the event requested it via {@code request.sendCompletion}, dispatches its {@code
+	 * CONTENT_COMPLETE} response event. This is the per-event completion action, called either early
+	 * (index-advance) or at stream close.
+	 *
+	 * @param requestId the batch request id, attached to the completion event data
+	 * @param event the waiting event to complete
+	 */
+	private void completeEvent(final String requestId, final Event event) {
+		CompletionCallbacksManager.getInstance().unregisterCallback(event.getUniqueIdentifier());
 
-					MobileCore.dispatchEvent(responseEvent);
-				}
+		if (sendCompletionRequested(event)) {
+			// send completion event
+			Map<String, Object> eventData = new HashMap<>();
+			addEventAndRequestIdToData(eventData, requestId, null);
+
+			Event responseEvent = new Event.Builder(
+				EdgeConstants.EventName.CONTENT_COMPLETE,
+				EventType.EDGE,
+				EventSource.CONTENT_COMPLETE
+			)
+				.setEventData(eventData)
+				.inResponseToEvent(event)
+				.build();
+
+			MobileCore.dispatchEvent(responseEvent);
+		}
+	}
+
+	/**
+	 * Records the highest indexed {@code eventIndex} observed so far for {@code requestId}, used to
+	 * drive early per-event completion. No-op when early completion is disabled or the index is not a
+	 * real per-event index ({@link EdgeEventHandle#ABSENT_EVENT_INDEX}, i.e. global handles / no-index
+	 * broadcast errors — those must never advance completion).
+	 *
+	 * <p>If an index arrives that is lower than the completion boundary already reached, that violates
+	 * the assumed grouping (data for an event that was already completed); it is logged at WARNING for
+	 * investigation and otherwise ignored (the boundary is never moved backwards, so no event is
+	 * completed twice).
+	 *
+	 * @param requestId the batch request id
+	 * @param index the eventIndex observed on a handle/error/warning fragment
+	 */
+	private void recordObservedIndex(final String requestId, final int index) {
+		if (!earlyPerEventCompletionEnabled || index < 0) {
+			return;
+		}
+
+		synchronized (mutex) {
+			final Integer completed = nextCompletionIndex.get(requestId);
+			if (completed != null && index < completed) {
+				Log.warning(
+					LOG_TAG,
+					LOG_SOURCE,
+					"Unexpected response ordering: eventIndex %d arrived for request id (%s) after events through index %d were already completed. Not re-completing; investigate response grouping/ordering.",
+					index,
+					requestId,
+					completed - 1
+				);
+				return;
 			}
+
+			final Integer current = highestObservedIndex.get(requestId);
+			if (current == null || index > current) {
+				highestObservedIndex.put(requestId, index);
+			}
+		}
+	}
+
+	/**
+	 * @return the highest indexed {@code eventIndex} observed so far for {@code requestId}, or -1 if
+	 * none has been observed.
+	 */
+	private int highestObservedIndexFor(final String requestId) {
+		synchronized (mutex) {
+			final Integer value = highestObservedIndex.get(requestId);
+			return value == null ? -1 : value;
+		}
+	}
+
+	/**
+	 * Completes every waiting event for {@code requestId} whose position is at or after the current
+	 * completion boundary and strictly below {@code exclusiveUpperBound}, advancing the boundary so
+	 * each event completes exactly once. Events to complete are collected under {@code mutex} and the
+	 * actual completion (which dispatches events) is performed outside the lock.
+	 *
+	 * @param requestId the batch request id
+	 * @param exclusiveUpperBound complete events with index in {@code [nextCompletionIndex,
+	 *     min(exclusiveUpperBound, size))}
+	 */
+	private void sweepCompletions(final String requestId, final int exclusiveUpperBound) {
+		final List<Event> toComplete = new ArrayList<>();
+		synchronized (mutex) {
+			final List<Event> events = sentEventsWaitingResponse.get(requestId);
+			if (events == null) {
+				return;
+			}
+			int next = nextCompletionIndex.containsKey(requestId) ? nextCompletionIndex.get(requestId) : 0;
+			final int limit = Math.min(exclusiveUpperBound, events.size());
+			while (next < limit) {
+				toComplete.add(events.get(next));
+				next++;
+			}
+			nextCompletionIndex.put(requestId, next);
+		}
+
+		for (final Event event : toComplete) {
+			completeEvent(requestId, event);
 		}
 	}
 
@@ -437,6 +588,19 @@ class NetworkResponseHandler {
 						requestId
 					);
 				}
+			}
+
+			// Track the highest per-event index seen, to drive early per-event completion. Global
+			// handles (ABSENT_EVENT_INDEX) do not advance completion.
+			recordObservedIndex(requestId, handleEventIndex);
+
+			// Complete any lower-indexed events still pending BEFORE dispatching this handle's data.
+			// Observing this handle's index means every lower index has no more data coming, so their
+			// completions (and whatever they read from downstream shared state, e.g. a listener's own
+			// in-progress accumulator) must fire before this handle is dispatched — not after, which
+			// would let this handle's data land ahead of a still-pending sibling's completion.
+			if (earlyPerEventCompletionEnabled && handleEventIndex != EdgeEventHandle.ABSENT_EVENT_INDEX) {
+				sweepCompletions(requestId, handleEventIndex);
 			}
 
 			// Dispatched events add the event and request IDs to the data, so use a copy of the data
@@ -674,6 +838,16 @@ class NetworkResponseHandler {
 					? DataReader.optInt(report, EdgeJson.Response.EventHandle.EVENT_INDEX, EdgeEventHandle.ABSENT_EVENT_INDEX)
 					: EdgeEventHandle.ABSENT_EVENT_INDEX;
 
+			// Track the highest per-event index seen, to drive early per-event completion. No-index
+			// (root/broadcast) errors do not advance completion.
+			recordObservedIndex(requestId, eventIndex);
+
+			// Complete any lower-indexed events still pending BEFORE dispatching this error's data —
+			// same ordering guarantee as processEventHandles, applied to the error/warning channel.
+			if (earlyPerEventCompletionEnabled && eventIndex != EdgeEventHandle.ABSENT_EVENT_INDEX) {
+				sweepCompletions(requestId, eventIndex);
+			}
+
 			logErrorMessage(currentError, isError, requestId);
 
 			final EdgeEventError edgeEventError = isError ? buildEdgeEventError(eventDataResponse) : null;
@@ -703,6 +877,27 @@ class NetworkResponseHandler {
 					CompletionCallbacksManager.getInstance().eventErrorReceived(eventId, edgeEventError);
 				}
 			} else {
+				// A no-eventIndex error/warning applies to the whole request. Per the Konductor team,
+				// a root-level error means the whole batch failed atomically — it should not arrive
+				// after events already streamed successful per-event data. If early completion is on and
+				// some events already completed, flag it: those events did not receive this error.
+				if (earlyPerEventCompletionEnabled) {
+					final Integer completed;
+					synchronized (mutex) {
+						completed = nextCompletionIndex.get(requestId);
+					}
+					if (completed != null && completed > 0) {
+						Log.warning(
+							LOG_TAG,
+							LOG_SOURCE,
+							"Received a no-eventIndex %s for request id (%s) after %d event(s) were already early-completed; those events did not receive it. Root-level errors are expected only when the whole batch fails — investigate.",
+							isError ? "error" : "warning",
+							requestId,
+							completed
+						);
+					}
+				}
+
 				final List<String> waitingIds = getWaitingEvents(requestId);
 				if (waitingIds.isEmpty()) {
 					// No registered events for this requestId — dispatch as broadcast (null parentId).

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
@@ -228,7 +228,6 @@ class NetworkResponseHandler {
 		} catch (JSONException e) {
 			// ok, ignore if there are no warnings
 		}
-
 		// Early per-event completion happens inline as each handle/error/warning is processed above:
 		// observing eventIndex M sweeps completions for events 0..M-1 (see processEventHandles /
 		// dispatchEventErrors). The highest index seen (and anything still pending) completes at stream
@@ -629,8 +628,10 @@ class NetworkResponseHandler {
 	 * by design — these are broadcast globally rather than attributed to a specific event.
 	 */
 	private boolean isGlobalHandleType(final String handleType) {
-		return EdgeJson.Response.EventHandle.Store.TYPE.equals(handleType) ||
-			EdgeJson.Response.EventHandle.LocationHint.TYPE.equals(handleType);
+		return (
+			EdgeJson.Response.EventHandle.Store.TYPE.equals(handleType) ||
+			EdgeJson.Response.EventHandle.LocationHint.TYPE.equals(handleType)
+		);
 	}
 
 	private void dispatchEventResponse(
@@ -729,7 +730,12 @@ class NetworkResponseHandler {
 	 */
 	private void dispatchEventErrors(final JSONArray errorsArray, final boolean isError, final String requestId) {
 		if (JSONUtils.isNullOrEmpty(errorsArray)) {
-			Log.trace(LOG_TAG, LOG_SOURCE, "Received null/empty %s array, nothing to handle", isError ? "errors" : "warnings");
+			Log.trace(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Received null/empty %s array, nothing to handle",
+				isError ? "errors" : "warnings"
+			);
 			return;
 		}
 
@@ -771,10 +777,15 @@ class NetworkResponseHandler {
 				EdgeJson.Response.EventHandle.REPORT,
 				null
 			);
-			final boolean hasEventIndex = report != null && report.containsKey(EdgeJson.Response.EventHandle.EVENT_INDEX);
+			final boolean hasEventIndex =
+				report != null && report.containsKey(EdgeJson.Response.EventHandle.EVENT_INDEX);
 			final int eventIndex = hasEventIndex
-					? DataReader.optInt(report, EdgeJson.Response.EventHandle.EVENT_INDEX, EdgeEventHandle.ABSENT_EVENT_INDEX)
-					: EdgeEventHandle.ABSENT_EVENT_INDEX;
+				? DataReader.optInt(
+					report,
+					EdgeJson.Response.EventHandle.EVENT_INDEX,
+					EdgeEventHandle.ABSENT_EVENT_INDEX
+				)
+				: EdgeEventHandle.ABSENT_EVENT_INDEX;
 
 			// Complete any lower-indexed events still pending BEFORE dispatching this error's data —
 			// same ordering guarantee as processEventHandles, applied to the error/warning channel.

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/NetworkResponseHandler.java
@@ -156,12 +156,8 @@ class NetworkResponseHandler {
 				eventIds.add(event.getUniqueIdentifier());
 			}
 
-			if (!temp.isEmpty()) {
-				return new ArrayList<>(eventIds);
-			}
+			return eventIds;
 		}
-
-		return Collections.emptyList();
 	}
 
 	/**

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/RetryResult.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/RetryResult.java
@@ -26,7 +26,8 @@ class RetryResult {
 	 * @param shouldRetry value indicating if the hit should be retried
 	 */
 	RetryResult(final EdgeNetworkService.Retry shouldRetry) {
-		this.networkRequestOutcome = shouldRetry == EdgeNetworkService.Retry.YES
+		this.networkRequestOutcome =
+			shouldRetry == EdgeNetworkService.Retry.YES
 				? EdgeNetworkService.NetworkRequestOutcome.RETRY
 				: EdgeNetworkService.NetworkRequestOutcome.SUCCESS;
 	}
@@ -40,7 +41,8 @@ class RetryResult {
 	RetryResult(final EdgeNetworkService.Retry shouldRetry, final int retryIntervalSeconds) {
 		this.retryIntervalSeconds =
 			retryIntervalSeconds > 0 ? retryIntervalSeconds : EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS;
-		this.networkRequestOutcome = shouldRetry == EdgeNetworkService.Retry.YES
+		this.networkRequestOutcome =
+			shouldRetry == EdgeNetworkService.Retry.YES
 				? EdgeNetworkService.NetworkRequestOutcome.RETRY
 				: EdgeNetworkService.NetworkRequestOutcome.SUCCESS;
 	}
@@ -67,8 +69,8 @@ class RetryResult {
 	 */
 	public EdgeNetworkService.Retry getShouldRetry() {
 		return networkRequestOutcome == EdgeNetworkService.NetworkRequestOutcome.RETRY
-				? EdgeNetworkService.Retry.YES
-				: EdgeNetworkService.Retry.NO;
+			? EdgeNetworkService.Retry.YES
+			: EdgeNetworkService.Retry.NO;
 	}
 
 	/**

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/RetryResult.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/RetryResult.java
@@ -16,7 +16,6 @@ package com.adobe.marketing.mobile;
  */
 class RetryResult {
 
-	private final EdgeNetworkService.Retry shouldRetry;
 	private int retryIntervalSeconds = EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS;
 	private final EdgeNetworkService.NetworkRequestOutcome networkRequestOutcome;
 	private String responseBody = null;
@@ -27,7 +26,6 @@ class RetryResult {
 	 * @param shouldRetry value indicating if the hit should be retried
 	 */
 	RetryResult(final EdgeNetworkService.Retry shouldRetry) {
-		this.shouldRetry = shouldRetry;
 		this.networkRequestOutcome = shouldRetry == EdgeNetworkService.Retry.YES
 				? EdgeNetworkService.NetworkRequestOutcome.RETRY
 				: EdgeNetworkService.NetworkRequestOutcome.SUCCESS;
@@ -40,7 +38,6 @@ class RetryResult {
 	 * @param retryIntervalSeconds value in seconds indicating the retry interval
 	 */
 	RetryResult(final EdgeNetworkService.Retry shouldRetry, final int retryIntervalSeconds) {
-		this.shouldRetry = shouldRetry;
 		this.retryIntervalSeconds =
 			retryIntervalSeconds > 0 ? retryIntervalSeconds : EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS;
 		this.networkRequestOutcome = shouldRetry == EdgeNetworkService.Retry.YES
@@ -57,20 +54,21 @@ class RetryResult {
 	 */
 	RetryResult(final EdgeNetworkService.NetworkRequestOutcome outcome, final int retryIntervalSeconds) {
 		this.networkRequestOutcome = outcome;
-		this.shouldRetry = outcome == EdgeNetworkService.NetworkRequestOutcome.RETRY
-				? EdgeNetworkService.Retry.YES
-				: EdgeNetworkService.Retry.NO;
 		this.retryIntervalSeconds =
 			retryIntervalSeconds > 0 ? retryIntervalSeconds : EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS;
 	}
 
 	/**
-	 * Gets the value determining if this hit should be retried.
+	 * Gets the value determining if this hit should be retried, derived from the
+	 * {@link EdgeNetworkService.NetworkRequestOutcome}: {@code RETRY} maps to {@link EdgeNetworkService.Retry#YES},
+	 * every other outcome to {@link EdgeNetworkService.Retry#NO}.
 	 *
 	 * @return An EdgeNetworkService.Retry value determining if the hit should be retried
 	 */
 	public EdgeNetworkService.Retry getShouldRetry() {
-		return shouldRetry;
+		return networkRequestOutcome == EdgeNetworkService.NetworkRequestOutcome.RETRY
+				? EdgeNetworkService.Retry.YES
+				: EdgeNetworkService.Retry.NO;
 	}
 
 	/**

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/RetryResult.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/RetryResult.java
@@ -18,6 +18,8 @@ class RetryResult {
 
 	private final EdgeNetworkService.Retry shouldRetry;
 	private int retryIntervalSeconds = EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS;
+	private final EdgeNetworkService.NetworkRequestOutcome networkRequestOutcome;
+	private String responseBody = null;
 
 	/**
 	 * Constructs a {@link RetryResult} with the specified retry value and default retry interval of 5 seconds.
@@ -26,6 +28,9 @@ class RetryResult {
 	 */
 	RetryResult(final EdgeNetworkService.Retry shouldRetry) {
 		this.shouldRetry = shouldRetry;
+		this.networkRequestOutcome = shouldRetry == EdgeNetworkService.Retry.YES
+				? EdgeNetworkService.NetworkRequestOutcome.RETRY
+				: EdgeNetworkService.NetworkRequestOutcome.SUCCESS;
 	}
 
 	/**
@@ -36,6 +41,25 @@ class RetryResult {
 	 */
 	RetryResult(final EdgeNetworkService.Retry shouldRetry, final int retryIntervalSeconds) {
 		this.shouldRetry = shouldRetry;
+		this.retryIntervalSeconds =
+			retryIntervalSeconds > 0 ? retryIntervalSeconds : EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS;
+		this.networkRequestOutcome = shouldRetry == EdgeNetworkService.Retry.YES
+				? EdgeNetworkService.NetworkRequestOutcome.RETRY
+				: EdgeNetworkService.NetworkRequestOutcome.SUCCESS;
+	}
+
+	/**
+	 * Constructs a {@link RetryResult} with an explicit {@link EdgeNetworkService.NetworkRequestOutcome},
+	 * used by batch-aware callers that need finer-grained classification than retry/no-retry.
+	 *
+	 * @param outcome the granular outcome of the network attempt
+	 * @param retryIntervalSeconds retry wait in seconds (only meaningful when outcome is RETRY)
+	 */
+	RetryResult(final EdgeNetworkService.NetworkRequestOutcome outcome, final int retryIntervalSeconds) {
+		this.networkRequestOutcome = outcome;
+		this.shouldRetry = outcome == EdgeNetworkService.NetworkRequestOutcome.RETRY
+				? EdgeNetworkService.Retry.YES
+				: EdgeNetworkService.Retry.NO;
 		this.retryIntervalSeconds =
 			retryIntervalSeconds > 0 ? retryIntervalSeconds : EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS;
 	}
@@ -56,5 +80,27 @@ class RetryResult {
 	 */
 	public int getRetryIntervalSeconds() {
 		return retryIntervalSeconds;
+	}
+
+	/**
+	 * Gets the granular network outcome, used by batch-aware processors to decide the next queue action.
+	 *
+	 * @return the {@link EdgeNetworkService.NetworkRequestOutcome} for this result
+	 */
+	public EdgeNetworkService.NetworkRequestOutcome getNetworkRequestOutcome() {
+		return networkRequestOutcome;
+	}
+
+	/**
+	 * Returns the server error body captured for a terminal 400 response, or {@code null} if none
+	 * was captured. Only meaningful when {@link #getNetworkRequestOutcome()} is
+	 * {@link EdgeNetworkService.NetworkRequestOutcome#EXPLODE_400}.
+	 */
+	String getResponseBody() {
+		return responseBody;
+	}
+
+	void setResponseBody(final String responseBody) {
+		this.responseBody = responseBody;
 	}
 }

--- a/code/edge/src/main/java/com/adobe/marketing/mobile/RetryResult.java
+++ b/code/edge/src/main/java/com/adobe/marketing/mobile/RetryResult.java
@@ -18,7 +18,6 @@ class RetryResult {
 
 	private int retryIntervalSeconds = EdgeConstants.Defaults.RETRY_INTERVAL_SECONDS;
 	private final EdgeNetworkService.NetworkRequestOutcome networkRequestOutcome;
-	private String responseBody = null;
 
 	/**
 	 * Constructs a {@link RetryResult} with the specified retry value and default retry interval of 5 seconds.
@@ -89,18 +88,5 @@ class RetryResult {
 	 */
 	public EdgeNetworkService.NetworkRequestOutcome getNetworkRequestOutcome() {
 		return networkRequestOutcome;
-	}
-
-	/**
-	 * Returns the server error body captured for a terminal 400 response, or {@code null} if none
-	 * was captured. Only meaningful when {@link #getNetworkRequestOutcome()} is
-	 * {@link EdgeNetworkService.NetworkRequestOutcome#EXPLODE_400}.
-	 */
-	String getResponseBody() {
-		return responseBody;
-	}
-
-	void setResponseBody(final String responseBody) {
-		this.responseBody = responseBody;
 	}
 }

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/CompletionCallbacksManagerTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/CompletionCallbacksManagerTests.java
@@ -270,4 +270,120 @@ public class CompletionCallbacksManagerTests {
 	public void testEventHandleReceived_withUnregisteredUniqueEvent_doesNotCrash() {
 		CompletionCallbacksManager.getInstance().eventHandleReceived(uniqueEventId, eventHandle);
 	}
+
+	// ----------- EdgeCallbackWithError: per-event error delivery
+
+	@Test
+	public void testRegisterEdgeCallbackWithError_thenHandleAndErrorReceived_bothDelivered()
+		throws InterruptedException {
+		final List<EdgeEventHandle> receivedHandles = new ArrayList<>();
+		final List<EdgeEventError> receivedErrors = new ArrayList<>();
+
+		CompletionCallbacksManager
+			.getInstance()
+			.registerCallback(
+				uniqueEventId,
+				new EdgeCallbackWithError() {
+					@Override
+					public void onComplete(final List<EdgeEventHandle> handles) {
+						receivedHandles.addAll(handles);
+						latchOfOne.countDown();
+					}
+
+					@Override
+					public void onError(final List<EdgeEventError> errors) {
+						receivedErrors.addAll(errors);
+						anotherLatchOfOne.countDown();
+					}
+				}
+			);
+
+		final EdgeEventError error = new EdgeEventError(
+			"https://ns.adobe.com/aep/errors/EXEG-0201-503",
+			503,
+			"Service Unavailable",
+			"The service is temporarily unavailable"
+		);
+		CompletionCallbacksManager.getInstance().eventHandleReceived(uniqueEventId, eventHandle);
+		CompletionCallbacksManager.getInstance().eventErrorReceived(uniqueEventId, error);
+		CompletionCallbacksManager.getInstance().unregisterCallback(uniqueEventId);
+
+		assertTrue("onComplete not called", latchOfOne.await(100, TimeUnit.MILLISECONDS));
+		assertTrue("onError not called", anotherLatchOfOne.await(100, TimeUnit.MILLISECONDS));
+		assertEquals(1, receivedHandles.size());
+		assertEquals(1, receivedErrors.size());
+		final EdgeEventError delivered = receivedErrors.get(0);
+		assertEquals("https://ns.adobe.com/aep/errors/EXEG-0201-503", delivered.getType());
+		assertEquals(503, delivered.getStatus());
+		assertEquals("Service Unavailable", delivered.getTitle());
+		assertEquals("The service is temporarily unavailable", delivered.getDetail());
+	}
+
+	@Test
+	public void testRegisterEdgeCallbackWithError_thenUnregisterWithNoErrors_onErrorNotCalled()
+		throws InterruptedException {
+		final boolean[] onErrorCalled = { false };
+
+		CompletionCallbacksManager
+			.getInstance()
+			.registerCallback(
+				uniqueEventId,
+				new EdgeCallbackWithError() {
+					@Override
+					public void onComplete(final List<EdgeEventHandle> handles) {
+						latchOfOne.countDown();
+					}
+
+					@Override
+					public void onError(final List<EdgeEventError> errors) {
+						onErrorCalled[0] = true;
+					}
+				}
+			);
+
+		CompletionCallbacksManager.getInstance().eventHandleReceived(uniqueEventId, eventHandle);
+		CompletionCallbacksManager.getInstance().unregisterCallback(uniqueEventId);
+
+		assertTrue("onComplete not called", latchOfOne.await(100, TimeUnit.MILLISECONDS));
+		// No errors were accumulated, so onError must not fire.
+		assertFalse("onError should not be called when there are no errors", onErrorCalled[0]);
+	}
+
+	@Test
+	public void testRegisterPlainEdgeCallback_thenErrorReceived_doesNotCrash_completionStillCalled()
+		throws InterruptedException {
+		final List<EdgeEventHandle> receivedHandles = new ArrayList<>();
+
+		// A plain EdgeCallback (not EdgeCallbackWithError) must not receive errors and must not crash.
+		CompletionCallbacksManager
+			.getInstance()
+			.registerCallback(
+				uniqueEventId,
+				handles -> {
+					receivedHandles.addAll(handles);
+					latchOfOne.countDown();
+				}
+			);
+
+		CompletionCallbacksManager
+			.getInstance()
+			.eventErrorReceived(uniqueEventId, new EdgeEventError("type", 500, "title", null));
+		CompletionCallbacksManager.getInstance().eventHandleReceived(uniqueEventId, eventHandle);
+		CompletionCallbacksManager.getInstance().unregisterCallback(uniqueEventId);
+
+		assertTrue(latchOfOne.await(100, TimeUnit.MILLISECONDS));
+		assertEquals(1, receivedHandles.size());
+	}
+
+	@Test
+	public void testEventErrorReceived_withNullEmptyUniqueEvent_doesNotCrash() {
+		final EdgeEventError error = new EdgeEventError("type", 500, "title", null);
+		CompletionCallbacksManager.getInstance().eventErrorReceived(null, error);
+		CompletionCallbacksManager.getInstance().eventErrorReceived("", error);
+	}
+
+	@Test
+	public void testEventErrorReceived_withNullError_doesNotCrash() {
+		CompletionCallbacksManager.getInstance().eventErrorReceived(uniqueEventId, null);
+	}
 }

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBatchingHitQueueTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBatchingHitQueueTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import com.adobe.marketing.mobile.services.DataEntity;
 import com.adobe.marketing.mobile.services.DataQueue;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -163,26 +164,70 @@ public class EdgeBatchingHitQueueTest {
 	}
 
 	// -------------------------------------------------------------------------
-	// PARTIAL_REMOVE outcome — remove resolved head count, schedule retry
+	// EXPLODE outcome — drain individually via forced batch-size-1, one at a time
 	// -------------------------------------------------------------------------
 
 	@Test
-	public void testBeginProcessing_partialRemove_removesResolvedCount() throws InterruptedException {
+	public void testBeginProcessing_explode_drainsOneAtATime_neverRemovesAsWholeBatch() throws InterruptedException {
+		// Batch of 3 gets a 400 (explode(3)); each of the 3 is then resolved individually via the
+		// ordinary single-entity path, forced to batchSize 1 regardless of config.
 		List<DataEntity> batch = buildBatchEntities(3, true);
-		DataEntity head = batch.get(0);
-		when(mockDataQueue.peek()).thenReturn(head);
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		when(mockDataQueue.peek())
+			.thenReturn(batch.get(0), batch.get(0), batch.get(1), batch.get(2))
+			.thenAnswer(inv -> { latch.countDown(); return null; });
 		when(mockDataQueue.count()).thenReturn(3);
 		when(mockDataQueue.peek(3)).thenReturn(batch);
-		when(mockProcessor.processBatch(batch)).thenReturn(BatchOutcome.partialRemove(2, 15));
+		when(mockProcessor.processBatch(batch)).thenReturn(BatchOutcome.explode(3));
+		when(mockProcessor.processBatch(Collections.singletonList(batch.get(0))))
+			.thenReturn(BatchOutcome.done(1));
+		when(mockProcessor.processBatch(Collections.singletonList(batch.get(1))))
+			.thenReturn(BatchOutcome.done(1));
+		when(mockProcessor.processBatch(Collections.singletonList(batch.get(2))))
+			.thenReturn(BatchOutcome.done(1));
 
 		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
 		hitQueue.beginProcessing();
 
-		Thread.sleep(150);
+		latch.await(2, TimeUnit.SECONDS);
 
-		// Only the 2 resolved head entities removed
-		verify(mockDataQueue, times(1)).remove(2);
+		// The original batch-sized peek happened exactly once (the failed attempt); the 3 drain
+		// cycles never re-peek a batch window (peek(int) is called exactly this once, total).
+		verify(mockDataQueue, times(1)).peek(anyInt());
+		verify(mockDataQueue, times(1)).peek(3);
+		// Each of the 3 drained entities removed individually — never as a group of 3.
+		verify(mockDataQueue, times(3)).remove(1);
 		verify(mockDataQueue, never()).remove(3);
+	}
+
+	@Test
+	public void testBeginProcessing_explode_recoverableFailureDuringDrain_retriesInPlace_doesNotSkip()
+		throws InterruptedException {
+		// Batch of 2 gets a 400 (explode(2)); the first drained entity hits a recoverable failure and
+		// must be retried in place — never skipped, never removed — exactly like a non-batched retry.
+		List<DataEntity> batch = buildBatchEntities(2, true);
+		final CountDownLatch retrySeen = new CountDownLatch(1);
+
+		when(mockDataQueue.peek())
+			.thenReturn(batch.get(0))
+			.thenAnswer(inv -> { retrySeen.countDown(); return batch.get(0); });
+		when(mockDataQueue.count()).thenReturn(2);
+		when(mockDataQueue.peek(2)).thenReturn(batch);
+		when(mockProcessor.processBatch(batch)).thenReturn(BatchOutcome.explode(2));
+		when(mockProcessor.processBatch(Collections.singletonList(batch.get(0))))
+			.thenReturn(BatchOutcome.retryBatch(30));
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.beginProcessing();
+
+		retrySeen.await(2, TimeUnit.SECONDS);
+
+		// Never removed — the retrying entity stays queued, retried in place.
+		verify(mockDataQueue, never()).remove(anyInt());
+		verify(mockDataQueue, never()).remove();
+		// The second entity in the batch was never attempted while the first is still retrying.
+		verify(mockProcessor, never()).processBatch(Collections.singletonList(batch.get(1)));
 	}
 
 	// -------------------------------------------------------------------------

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBatchingHitQueueTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBatchingHitQueueTest.java
@@ -82,7 +82,7 @@ public class EdgeBatchingHitQueueTest {
 		when(mockDataQueue.peek())
 			.thenReturn(entity)
 			.thenAnswer(inv -> { latch.countDown(); return null; });
-		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done());
+		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done(1));
 
 		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
 		hitQueue.beginProcessing();
@@ -104,7 +104,7 @@ public class EdgeBatchingHitQueueTest {
 			.thenAnswer(inv -> { latch.countDown(); return null; });
 		when(mockDataQueue.count()).thenReturn(3);
 		when(mockDataQueue.peek(3)).thenReturn(batch);
-		when(mockProcessor.processBatch(batch)).thenReturn(BatchOutcome.done());
+		when(mockProcessor.processBatch(batch)).thenReturn(BatchOutcome.done(3));
 
 		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
 		hitQueue.beginProcessing();
@@ -112,6 +112,34 @@ public class EdgeBatchingHitQueueTest {
 		latch.await(2, TimeUnit.SECONDS);
 
 		verify(mockDataQueue, times(1)).remove(3);
+	}
+
+	@Test
+	public void testBeginProcessing_done_truncatedResolvedCount_removesOnlyResolvedPrefix() throws InterruptedException {
+		// Regression test: processBatch may resolve fewer entities than the peeked window (e.g. a
+		// window truncated at a Consent/Reset/decode-failure boundary). The queue must remove only
+		// the resolved prefix reported on BatchOutcome, never the full peeked window size — otherwise
+		// the untouched trailing entities are silently lost.
+		List<DataEntity> batch = buildBatchEntities(3, true);
+		DataEntity head = batch.get(0);
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		when(mockDataQueue.peek())
+			.thenReturn(head)
+			.thenAnswer(inv -> { latch.countDown(); return null; });
+		when(mockDataQueue.count()).thenReturn(3);
+		when(mockDataQueue.peek(3)).thenReturn(batch);
+		// Only 2 of the 3 peeked entities were actually resolved (e.g. the 3rd was a Consent event
+		// that truncated the ExperienceEvent run).
+		when(mockProcessor.processBatch(batch)).thenReturn(BatchOutcome.done(2));
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.beginProcessing();
+
+		latch.await(2, TimeUnit.SECONDS);
+
+		verify(mockDataQueue, times(1)).remove(2);
+		verify(mockDataQueue, never()).remove(3);
 	}
 
 	// -------------------------------------------------------------------------
@@ -170,7 +198,7 @@ public class EdgeBatchingHitQueueTest {
 		when(mockDataQueue.peek())
 			.thenReturn(entity)
 			.thenAnswer(inv -> { latch.countDown(); return null; });
-		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done());
+		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done(1));
 
 		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
 		hitQueue.beginProcessing();
@@ -195,7 +223,7 @@ public class EdgeBatchingHitQueueTest {
 			.thenAnswer(inv -> { latch.countDown(); return null; });
 		when(mockDataQueue.count()).thenReturn(queueCount);
 		when(mockDataQueue.peek(expectedBatchSize)).thenReturn(batch);
-		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done());
+		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done(expectedBatchSize));
 
 		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
 		hitQueue.beginProcessing();
@@ -217,7 +245,7 @@ public class EdgeBatchingHitQueueTest {
 			.thenAnswer(inv -> { latch.countDown(); return null; });
 		when(mockDataQueue.count()).thenReturn(queueCount);
 		when(mockDataQueue.peek(EdgeConstants.Defaults.MAX_BATCH_SIZE)).thenReturn(batch);
-		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done());
+		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done(EdgeConstants.Defaults.MAX_BATCH_SIZE));
 
 		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
 		hitQueue.beginProcessing();

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBatchingHitQueueTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBatchingHitQueueTest.java
@@ -48,8 +48,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class EdgeBatchingHitQueueTest {
 
-	@Mock DataQueue mockDataQueue;
-	@Mock EdgeHitProcessor mockProcessor;
+	@Mock
+	DataQueue mockDataQueue;
+
+	@Mock
+	EdgeHitProcessor mockProcessor;
 
 	private EdgeBatchingHitQueue hitQueue;
 	private ScheduledExecutorService executor;
@@ -82,7 +85,10 @@ public class EdgeBatchingHitQueueTest {
 		// First peek() returns the entity; second (next cycle, empty queue) fires the latch.
 		when(mockDataQueue.peek())
 			.thenReturn(entity)
-			.thenAnswer(inv -> { latch.countDown(); return null; });
+			.thenAnswer(inv -> {
+				latch.countDown();
+				return null;
+			});
 		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done(1));
 
 		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
@@ -102,7 +108,10 @@ public class EdgeBatchingHitQueueTest {
 
 		when(mockDataQueue.peek())
 			.thenReturn(head)
-			.thenAnswer(inv -> { latch.countDown(); return null; });
+			.thenAnswer(inv -> {
+				latch.countDown();
+				return null;
+			});
 		when(mockDataQueue.count()).thenReturn(3);
 		when(mockDataQueue.peek(3)).thenReturn(batch);
 		when(mockProcessor.processBatch(batch)).thenReturn(BatchOutcome.done(3));
@@ -116,7 +125,8 @@ public class EdgeBatchingHitQueueTest {
 	}
 
 	@Test
-	public void testBeginProcessing_done_truncatedResolvedCount_removesOnlyResolvedPrefix() throws InterruptedException {
+	public void testBeginProcessing_done_truncatedResolvedCount_removesOnlyResolvedPrefix()
+		throws InterruptedException {
 		// Regression test: processBatch may resolve fewer entities than the peeked window (e.g. a
 		// window truncated at a Consent/Reset/decode-failure boundary). The queue must remove only
 		// the resolved prefix reported on BatchOutcome, never the full peeked window size — otherwise
@@ -127,7 +137,10 @@ public class EdgeBatchingHitQueueTest {
 
 		when(mockDataQueue.peek())
 			.thenReturn(head)
-			.thenAnswer(inv -> { latch.countDown(); return null; });
+			.thenAnswer(inv -> {
+				latch.countDown();
+				return null;
+			});
 		when(mockDataQueue.count()).thenReturn(3);
 		when(mockDataQueue.peek(3)).thenReturn(batch);
 		// Only 2 of the 3 peeked entities were actually resolved (e.g. the 3rd was a Consent event
@@ -176,16 +189,16 @@ public class EdgeBatchingHitQueueTest {
 
 		when(mockDataQueue.peek())
 			.thenReturn(batch.get(0), batch.get(0), batch.get(1), batch.get(2))
-			.thenAnswer(inv -> { latch.countDown(); return null; });
+			.thenAnswer(inv -> {
+				latch.countDown();
+				return null;
+			});
 		when(mockDataQueue.count()).thenReturn(3);
 		when(mockDataQueue.peek(3)).thenReturn(batch);
 		when(mockProcessor.processBatch(batch)).thenReturn(BatchOutcome.explode(3));
-		when(mockProcessor.processBatch(Collections.singletonList(batch.get(0))))
-			.thenReturn(BatchOutcome.done(1));
-		when(mockProcessor.processBatch(Collections.singletonList(batch.get(1))))
-			.thenReturn(BatchOutcome.done(1));
-		when(mockProcessor.processBatch(Collections.singletonList(batch.get(2))))
-			.thenReturn(BatchOutcome.done(1));
+		when(mockProcessor.processBatch(Collections.singletonList(batch.get(0)))).thenReturn(BatchOutcome.done(1));
+		when(mockProcessor.processBatch(Collections.singletonList(batch.get(1)))).thenReturn(BatchOutcome.done(1));
+		when(mockProcessor.processBatch(Collections.singletonList(batch.get(2)))).thenReturn(BatchOutcome.done(1));
 
 		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
 		hitQueue.beginProcessing();
@@ -211,7 +224,10 @@ public class EdgeBatchingHitQueueTest {
 
 		when(mockDataQueue.peek())
 			.thenReturn(batch.get(0))
-			.thenAnswer(inv -> { retrySeen.countDown(); return batch.get(0); });
+			.thenAnswer(inv -> {
+				retrySeen.countDown();
+				return batch.get(0);
+			});
 		when(mockDataQueue.count()).thenReturn(2);
 		when(mockDataQueue.peek(2)).thenReturn(batch);
 		when(mockProcessor.processBatch(batch)).thenReturn(BatchOutcome.explode(2));
@@ -242,7 +258,10 @@ public class EdgeBatchingHitQueueTest {
 
 		when(mockDataQueue.peek())
 			.thenReturn(entity)
-			.thenAnswer(inv -> { latch.countDown(); return null; });
+			.thenAnswer(inv -> {
+				latch.countDown();
+				return null;
+			});
 		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done(1));
 
 		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
@@ -265,7 +284,10 @@ public class EdgeBatchingHitQueueTest {
 
 		when(mockDataQueue.peek())
 			.thenReturn(head)
-			.thenAnswer(inv -> { latch.countDown(); return null; });
+			.thenAnswer(inv -> {
+				latch.countDown();
+				return null;
+			});
 		when(mockDataQueue.count()).thenReturn(queueCount);
 		when(mockDataQueue.peek(expectedBatchSize)).thenReturn(batch);
 		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done(expectedBatchSize));
@@ -287,7 +309,10 @@ public class EdgeBatchingHitQueueTest {
 
 		when(mockDataQueue.peek())
 			.thenReturn(head)
-			.thenAnswer(inv -> { latch.countDown(); return null; });
+			.thenAnswer(inv -> {
+				latch.countDown();
+				return null;
+			});
 		when(mockDataQueue.count()).thenReturn(queueCount);
 		when(mockDataQueue.peek(EdgeConstants.Defaults.MAX_BATCH_SIZE)).thenReturn(batch);
 		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done(EdgeConstants.Defaults.MAX_BATCH_SIZE));

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBatchingHitQueueTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBatchingHitQueueTest.java
@@ -1,0 +1,278 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.adobe.marketing.mobile.services.DataEntity;
+import com.adobe.marketing.mobile.services.DataQueue;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Tests for {@link EdgeBatchingHitQueue} — queue peek/remove behaviour per {@link BatchOutcome},
+ * effective batch-size selection, and suspend/resume lifecycle.
+ *
+ * <p>Uses {@code MockitoJUnitRunner.Silent} to suppress strict-stub checks: several tests stub
+ * {@code queue.peek()} via an Answer that fires a latch on the second call, which looks like an
+ * "unnecessary" stub to the strict runner even though it controls test completion.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class EdgeBatchingHitQueueTest {
+
+	@Mock DataQueue mockDataQueue;
+	@Mock EdgeHitProcessor mockProcessor;
+
+	private EdgeBatchingHitQueue hitQueue;
+	private ScheduledExecutorService executor;
+	private Map<String, Object> edgeConfig;
+
+	@Before
+	public void setup() {
+		executor = Executors.newSingleThreadScheduledExecutor();
+		edgeConfig = new HashMap<>();
+		edgeConfig.put("edge.configId", "test-id");
+	}
+
+	@After
+	public void tearDown() {
+		if (hitQueue != null) {
+			hitQueue.close();
+		}
+		executor.shutdownNow();
+	}
+
+	// -------------------------------------------------------------------------
+	// DONE outcome — remove all entities in the batch
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testBeginProcessing_done_removesBatch() throws InterruptedException {
+		DataEntity entity = buildEntity(false);
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		// First peek() returns the entity; second (next cycle, empty queue) fires the latch.
+		when(mockDataQueue.peek())
+			.thenReturn(entity)
+			.thenAnswer(inv -> { latch.countDown(); return null; });
+		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done());
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.beginProcessing();
+
+		latch.await(2, TimeUnit.SECONDS);
+
+		// Exactly one entity removed (single-entity batch, batching off)
+		verify(mockDataQueue, times(1)).remove(1);
+	}
+
+	@Test
+	public void testBeginProcessing_done_batchOfThree_removesThree() throws InterruptedException {
+		List<DataEntity> batch = buildBatchEntities(3, true);
+		DataEntity head = batch.get(0);
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		when(mockDataQueue.peek())
+			.thenReturn(head)
+			.thenAnswer(inv -> { latch.countDown(); return null; });
+		when(mockDataQueue.count()).thenReturn(3);
+		when(mockDataQueue.peek(3)).thenReturn(batch);
+		when(mockProcessor.processBatch(batch)).thenReturn(BatchOutcome.done());
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.beginProcessing();
+
+		latch.await(2, TimeUnit.SECONDS);
+
+		verify(mockDataQueue, times(1)).remove(3);
+	}
+
+	// -------------------------------------------------------------------------
+	// RETRY_BATCH outcome — entities retained, nothing removed
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testBeginProcessing_retryBatch_doesNotRemoveEntities() throws InterruptedException {
+		DataEntity entity = buildEntity(false);
+		when(mockDataQueue.peek()).thenReturn(entity);
+		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.retryBatch(30));
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.beginProcessing();
+
+		Thread.sleep(150);
+
+		// Nothing removed — entities stay for retry
+		verify(mockDataQueue, never()).remove(anyInt());
+		verify(mockDataQueue, never()).remove();
+	}
+
+	// -------------------------------------------------------------------------
+	// PARTIAL_REMOVE outcome — remove resolved head count, schedule retry
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testBeginProcessing_partialRemove_removesResolvedCount() throws InterruptedException {
+		List<DataEntity> batch = buildBatchEntities(3, true);
+		DataEntity head = batch.get(0);
+		when(mockDataQueue.peek()).thenReturn(head);
+		when(mockDataQueue.count()).thenReturn(3);
+		when(mockDataQueue.peek(3)).thenReturn(batch);
+		when(mockProcessor.processBatch(batch)).thenReturn(BatchOutcome.partialRemove(2, 15));
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.beginProcessing();
+
+		Thread.sleep(150);
+
+		// Only the 2 resolved head entities removed
+		verify(mockDataQueue, times(1)).remove(2);
+		verify(mockDataQueue, never()).remove(3);
+	}
+
+	// -------------------------------------------------------------------------
+	// Effective batch-size selection
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testGetEffectiveBatchSize_batchingDisabled_doesNotCallPeekN() throws InterruptedException {
+		// When batching is off, the queue uses singletonList(head) — no peek(n) call.
+		DataEntity entity = buildEntity(false);
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		when(mockDataQueue.peek())
+			.thenReturn(entity)
+			.thenAnswer(inv -> { latch.countDown(); return null; });
+		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done());
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.beginProcessing();
+
+		latch.await(2, TimeUnit.SECONDS);
+
+		verify(mockDataQueue, never()).peek(anyInt());
+		verify(mockProcessor, atLeastOnce()).processBatch(any());
+	}
+
+	@Test
+	public void testGetEffectiveBatchSize_batchingEnabled_peeksMin_countAndMax() throws InterruptedException {
+		// 5 entries in queue, batching on → peek(min(5, MAX_BATCH_SIZE))
+		int queueCount = 5;
+		int expectedBatchSize = Math.min(queueCount, EdgeConstants.Defaults.MAX_BATCH_SIZE);
+		List<DataEntity> batch = buildBatchEntities(expectedBatchSize, true);
+		DataEntity head = batch.get(0);
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		when(mockDataQueue.peek())
+			.thenReturn(head)
+			.thenAnswer(inv -> { latch.countDown(); return null; });
+		when(mockDataQueue.count()).thenReturn(queueCount);
+		when(mockDataQueue.peek(expectedBatchSize)).thenReturn(batch);
+		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done());
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.beginProcessing();
+
+		latch.await(2, TimeUnit.SECONDS);
+
+		verify(mockDataQueue, times(1)).peek(expectedBatchSize);
+	}
+
+	@Test
+	public void testGetEffectiveBatchSize_batchingEnabled_queueLargerThanMax_capsAtMax() throws InterruptedException {
+		int queueCount = EdgeConstants.Defaults.MAX_BATCH_SIZE + 3;
+		List<DataEntity> batch = buildBatchEntities(EdgeConstants.Defaults.MAX_BATCH_SIZE, true);
+		DataEntity head = batch.get(0);
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		when(mockDataQueue.peek())
+			.thenReturn(head)
+			.thenAnswer(inv -> { latch.countDown(); return null; });
+		when(mockDataQueue.count()).thenReturn(queueCount);
+		when(mockDataQueue.peek(EdgeConstants.Defaults.MAX_BATCH_SIZE)).thenReturn(batch);
+		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done());
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.beginProcessing();
+
+		latch.await(2, TimeUnit.SECONDS);
+
+		verify(mockDataQueue, times(1)).peek(EdgeConstants.Defaults.MAX_BATCH_SIZE);
+		verify(mockDataQueue, never()).peek(queueCount);
+	}
+
+	// -------------------------------------------------------------------------
+	// Suspend
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testSuspend_stopsProcessing() throws InterruptedException {
+		DataEntity entity = buildEntity(false);
+		when(mockDataQueue.add(any())).thenReturn(true);
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.suspend();
+		hitQueue.queue(entity);
+
+		Thread.sleep(150);
+
+		verify(mockProcessor, never()).processBatch(any());
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private DataEntity buildEntity(final boolean batchingEnabled) {
+		Map<String, Object> config = new HashMap<>(edgeConfig);
+		if (batchingEnabled) {
+			config.put(EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED, true);
+		}
+
+		Map<String, Object> xdmData = new HashMap<>();
+		xdmData.put("test", "data");
+		Map<String, Object> eventData = new HashMap<>();
+		eventData.put("xdm", xdmData);
+
+		Event event = new Event.Builder("test", EventType.EDGE, EventSource.REQUEST_CONTENT)
+			.setEventData(eventData)
+			.build();
+
+		return new EdgeDataEntity(event, config, new HashMap<>()).toDataEntity();
+	}
+
+	private List<DataEntity> buildBatchEntities(final int count, final boolean batchingEnabled) {
+		List<DataEntity> list = new ArrayList<>();
+		for (int i = 0; i < count; i++) {
+			list.add(buildEntity(batchingEnabled));
+		}
+		return list;
+	}
+}

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBatchingHitQueueTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBatchingHitQueueTest.java
@@ -326,6 +326,118 @@ public class EdgeBatchingHitQueueTest {
 		verify(mockDataQueue, never()).peek(queueCount);
 	}
 
+	@Test
+	public void testGetEffectiveBatchSize_configuredMaxBatchSize_smallerThanDefault_honorsConfiguredValue()
+		throws InterruptedException {
+		// edge.batching.maxBatchSize=3 caps the window below the built-in default of 10.
+		final int configuredMax = 3;
+		List<DataEntity> batch = buildBatchEntities(configuredMax, true, configuredMax);
+		DataEntity head = batch.get(0);
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		when(mockDataQueue.peek())
+			.thenReturn(head)
+			.thenAnswer(inv -> {
+				latch.countDown();
+				return null;
+			});
+		when(mockDataQueue.count()).thenReturn(10);
+		when(mockDataQueue.peek(configuredMax)).thenReturn(batch);
+		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done(configuredMax));
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.beginProcessing();
+
+		latch.await(2, TimeUnit.SECONDS);
+
+		verify(mockDataQueue, times(1)).peek(configuredMax);
+		verify(mockDataQueue, never()).peek(EdgeConstants.Defaults.MAX_BATCH_SIZE);
+	}
+
+	@Test
+	public void testGetEffectiveBatchSize_configuredMaxBatchSize_largerThanDefault_honorsConfiguredValue()
+		throws InterruptedException {
+		// edge.batching.maxBatchSize=20 raises the window above the built-in default of 10.
+		final int configuredMax = 20;
+		List<DataEntity> batch = buildBatchEntities(configuredMax, true, configuredMax);
+		DataEntity head = batch.get(0);
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		when(mockDataQueue.peek())
+			.thenReturn(head)
+			.thenAnswer(inv -> {
+				latch.countDown();
+				return null;
+			});
+		when(mockDataQueue.count()).thenReturn(25);
+		when(mockDataQueue.peek(configuredMax)).thenReturn(batch);
+		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done(configuredMax));
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.beginProcessing();
+
+		latch.await(2, TimeUnit.SECONDS);
+
+		verify(mockDataQueue, times(1)).peek(configuredMax);
+		verify(mockDataQueue, never()).peek(EdgeConstants.Defaults.MAX_BATCH_SIZE);
+	}
+
+	@Test
+	public void testGetEffectiveBatchSize_configuredMaxBatchSize_exceedsLimit_clampsToLimit()
+		throws InterruptedException {
+		// edge.batching.maxBatchSize=50 exceeds MAX_BATCH_SIZE_LIMIT (20); clamped to the limit
+		// regardless of what was configured, so a misconfigured value can't grow the batch unbounded.
+		final int configuredMax = 50;
+		final int limit = EdgeConstants.Defaults.MAX_BATCH_SIZE_LIMIT;
+		List<DataEntity> batch = buildBatchEntities(limit, true, configuredMax);
+		DataEntity head = batch.get(0);
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		when(mockDataQueue.peek())
+			.thenReturn(head)
+			.thenAnswer(inv -> {
+				latch.countDown();
+				return null;
+			});
+		when(mockDataQueue.count()).thenReturn(100);
+		when(mockDataQueue.peek(limit)).thenReturn(batch);
+		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done(limit));
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.beginProcessing();
+
+		latch.await(2, TimeUnit.SECONDS);
+
+		verify(mockDataQueue, times(1)).peek(limit);
+		verify(mockDataQueue, never()).peek(configuredMax);
+	}
+
+	@Test
+	public void testGetEffectiveBatchSize_nonPositiveConfiguredMaxBatchSize_fallsBackToDefault()
+		throws InterruptedException {
+		// edge.batching.maxBatchSize=0 is not a usable value; falls back to the built-in default.
+		List<DataEntity> batch = buildBatchEntities(EdgeConstants.Defaults.MAX_BATCH_SIZE, true, 0);
+		DataEntity head = batch.get(0);
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		when(mockDataQueue.peek())
+			.thenReturn(head)
+			.thenAnswer(inv -> {
+				latch.countDown();
+				return null;
+			});
+		when(mockDataQueue.count()).thenReturn(EdgeConstants.Defaults.MAX_BATCH_SIZE + 5);
+		when(mockDataQueue.peek(EdgeConstants.Defaults.MAX_BATCH_SIZE)).thenReturn(batch);
+		when(mockProcessor.processBatch(any())).thenReturn(BatchOutcome.done(EdgeConstants.Defaults.MAX_BATCH_SIZE));
+
+		hitQueue = new EdgeBatchingHitQueue(mockDataQueue, mockProcessor, executor);
+		hitQueue.beginProcessing();
+
+		latch.await(2, TimeUnit.SECONDS);
+
+		verify(mockDataQueue, times(1)).peek(EdgeConstants.Defaults.MAX_BATCH_SIZE);
+	}
+
 	// -------------------------------------------------------------------------
 	// Suspend
 	// -------------------------------------------------------------------------
@@ -349,9 +461,16 @@ public class EdgeBatchingHitQueueTest {
 	// -------------------------------------------------------------------------
 
 	private DataEntity buildEntity(final boolean batchingEnabled) {
+		return buildEntity(batchingEnabled, null);
+	}
+
+	private DataEntity buildEntity(final boolean batchingEnabled, final Integer maxBatchSize) {
 		Map<String, Object> config = new HashMap<>(edgeConfig);
 		if (batchingEnabled) {
 			config.put(EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED, true);
+		}
+		if (maxBatchSize != null) {
+			config.put(EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE, maxBatchSize);
 		}
 
 		Map<String, Object> xdmData = new HashMap<>();
@@ -367,9 +486,17 @@ public class EdgeBatchingHitQueueTest {
 	}
 
 	private List<DataEntity> buildBatchEntities(final int count, final boolean batchingEnabled) {
+		return buildBatchEntities(count, batchingEnabled, null);
+	}
+
+	private List<DataEntity> buildBatchEntities(
+		final int count,
+		final boolean batchingEnabled,
+		final Integer maxBatchSize
+	) {
 		List<DataEntity> list = new ArrayList<>();
 		for (int i = 0; i < count; i++) {
-			list.add(buildEntity(batchingEnabled));
+			list.add(buildEntity(batchingEnabled, maxBatchSize));
 		}
 		return list;
 	}

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBatchingHitQueueTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBatchingHitQueueTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright 2024 Adobe. All rights reserved.
+  Copyright 2026 Adobe. All rights reserved.
   This file is licensed to you under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License. You may obtain a copy
   of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBundledBatchingConfigTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBundledBatchingConfigTests.java
@@ -1,0 +1,122 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.adobe.marketing.mobile.services.DeviceInforming;
+import com.adobe.marketing.mobile.services.ServiceProvider;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+public class EdgeBundledBatchingConfigTests {
+
+	@Mock
+	private ServiceProvider mockServiceProvider;
+
+	@Mock
+	private DeviceInforming mockDeviceInfoService;
+
+	private MockedStatic<ServiceProvider> mockServiceProviderStatic;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.openMocks(this);
+		mockServiceProviderStatic = mockStatic(ServiceProvider.class);
+		mockServiceProviderStatic.when(ServiceProvider::getInstance).thenReturn(mockServiceProvider);
+		when(mockServiceProvider.getDeviceInfoService()).thenReturn(mockDeviceInfoService);
+		EdgeBundledBatchingConfig.resetForTesting();
+	}
+
+	@After
+	public void tearDown() {
+		mockServiceProviderStatic.close();
+		EdgeBundledBatchingConfig.resetForTesting();
+	}
+
+	private InputStream streamOf(final String content) {
+		return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	public void testGet_validJson_parsesBothKeys() {
+		when(mockDeviceInfoService.getAsset(EdgeBundledBatchingConfig.BUNDLED_CONFIG_FILE_NAME))
+			.thenReturn(
+				streamOf(
+					"{" +
+					"\"edge.batching.enabled\": true," +
+					"\"edge.batching.eventNameAllowlist\": [\"Edge Optimize Proposition Interaction Request\"]" +
+					"}"
+				)
+			);
+
+		Map<String, Object> result = EdgeBundledBatchingConfig.get();
+
+		assertEquals(true, result.get("edge.batching.enabled"));
+		assertEquals(
+			Arrays.asList("Edge Optimize Proposition Interaction Request"),
+			result.get("edge.batching.eventNameAllowlist")
+		);
+	}
+
+	@Test
+	public void testGet_fileNotPresentInAssets_returnsEmptyMap() {
+		when(mockDeviceInfoService.getAsset(anyString())).thenReturn(null);
+
+		Map<String, Object> result = EdgeBundledBatchingConfig.get();
+
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	public void testGet_malformedJson_returnsEmptyMap() {
+		when(mockDeviceInfoService.getAsset(anyString())).thenReturn(streamOf("not valid json"));
+
+		Map<String, Object> result = EdgeBundledBatchingConfig.get();
+
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	public void testGet_emptyFileContent_returnsEmptyMap() {
+		when(mockDeviceInfoService.getAsset(anyString())).thenReturn(streamOf(""));
+
+		Map<String, Object> result = EdgeBundledBatchingConfig.get();
+
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	public void testGet_calledTwice_onlyReadsAssetOnce() {
+		when(mockDeviceInfoService.getAsset(anyString())).thenReturn(streamOf("{\"edge.batching.enabled\": true}"));
+
+		EdgeBundledBatchingConfig.get();
+		EdgeBundledBatchingConfig.get();
+
+		verify(mockDeviceInfoService, times(1)).getAsset(EdgeBundledBatchingConfig.BUNDLED_CONFIG_FILE_NAME);
+	}
+}

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBundledBatchingConfigTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeBundledBatchingConfigTests.java
@@ -63,13 +63,14 @@ public class EdgeBundledBatchingConfigTests {
 	}
 
 	@Test
-	public void testGet_validJson_parsesBothKeys() {
+	public void testGet_validJson_parsesAllKeys() {
 		when(mockDeviceInfoService.getAsset(EdgeBundledBatchingConfig.BUNDLED_CONFIG_FILE_NAME))
 			.thenReturn(
 				streamOf(
 					"{" +
 					"\"edge.batching.enabled\": true," +
-					"\"edge.batching.eventNameAllowlist\": [\"Edge Optimize Proposition Interaction Request\"]" +
+					"\"edge.batching.eventNameAllowlist\": [\"Edge Optimize Proposition Interaction Request\"]," +
+					"\"edge.batching.maxBatchSize\": 25" +
 					"}"
 				)
 			);
@@ -81,6 +82,7 @@ public class EdgeBundledBatchingConfigTests {
 			Arrays.asList("Edge Optimize Proposition Interaction Request"),
 			result.get("edge.batching.eventNameAllowlist")
 		);
+		assertEquals(25, result.get("edge.batching.maxBatchSize"));
 	}
 
 	@Test

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeEventHandleTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeEventHandleTests.java
@@ -143,7 +143,7 @@ public class EdgeEventHandleTests {
 	}
 
 	@Test
-	public void testEdgeEventHandle_whenHandleWithMissingEventIndex_parsesCorrectly_defaultIndex0() {
+	public void testEdgeEventHandle_whenHandleWithMissingEventIndex_parsesCorrectly_absentIndex() {
 		JSONObject handleJson = new JSONObject() {
 			{
 				try {
@@ -175,7 +175,10 @@ public class EdgeEventHandleTests {
 
 		assertNotNull(handle);
 		assertEquals("testType", handle.getType());
-		assertEquals(0, handle.getEventIndex());
+		// Absent eventIndex is represented as ABSENT_EVENT_INDEX (-1), not 0, so a handle
+		// without an index (e.g. a global state:store handle) is not mis-attributed to event[0]
+		// in a batch. Mirrors the iOS model where eventIndex is optional (nil when absent).
+		assertEquals(EdgeEventHandle.ABSENT_EVENT_INDEX, handle.getEventIndex());
 		JSONAsserts.assertEquals(expected, handle.getPayload());
 	}
 
@@ -191,7 +194,10 @@ public class EdgeEventHandleTests {
 
 		assertNotNull(handle);
 		assertEquals("testType", handle.getType());
-		assertEquals(0, handle.getEventIndex());
+		// Absent eventIndex is represented as ABSENT_EVENT_INDEX (-1), not 0, so a handle
+		// without an index (e.g. a global state:store handle) is not mis-attributed to event[0]
+		// in a batch. Mirrors the iOS model where eventIndex is optional (nil when absent).
+		assertEquals(EdgeEventHandle.ABSENT_EVENT_INDEX, handle.getEventIndex());
 		assertNull(handle.getPayload());
 	}
 
@@ -216,7 +222,10 @@ public class EdgeEventHandleTests {
 
 		assertNotNull(handle);
 		assertEquals("testType", handle.getType());
-		assertEquals(0, handle.getEventIndex());
+		// Absent eventIndex is represented as ABSENT_EVENT_INDEX (-1), not 0, so a handle
+		// without an index (e.g. a global state:store handle) is not mis-attributed to event[0]
+		// in a batch. Mirrors the iOS model where eventIndex is optional (nil when absent).
+		assertEquals(EdgeEventHandle.ABSENT_EVENT_INDEX, handle.getEventIndex());
 		assertNull(handle.getPayload());
 	}
 }

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorBatchTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorBatchTests.java
@@ -43,6 +43,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 /**
  * Tests for {@link EdgeHitProcessor#processBatch} — covering the unified single = batch-of-1
  * path, terminal-400 delivery (regression guard), explosion flow, and Consent/Reset terminal-400.
+ *
+ * <p>Single-event 400s are no longer classified as {@code EXPLODE_400} by (the real)
+ * {@link EdgeNetworkService#doRequest}; only a real N&gt;1 batch is. So tests exercising a
+ * single-event terminal-400 simulate what the real network layer does — invoking the injected
+ * {@link EdgeNetworkService.ResponseCallback}'s {@code onError}/{@code onComplete} — the same way
+ * {@code EdgeHitProcessorTests} does for the non-batching build.
  */
 @RunWith(MockitoJUnitRunner.class)
 public class EdgeHitProcessorBatchTests {
@@ -124,10 +130,10 @@ public class EdgeHitProcessorBatchTests {
 
 		BatchOutcome outcome = hitProcessor.processBatch(Collections.singletonList(entity));
 
-		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+		assertEquals(0, outcome.getRetryDelaySeconds()); // done -> process immediately, no retry delay
 		// Regression guard: DONE must report exactly how many entities were resolved, so the queue
 		// removes only those — never a stale/full peeked-window count.
-		assertEquals(1, outcome.getResolvedHeadCount());
+		assertEquals(1, outcome.getRemoveCount());
 		// Waiting events registered before the network call
 		verify(mockNetworkResponseHandler, times(1)).addWaitingEvents(anyString(), any());
 		// No error path triggered
@@ -143,8 +149,8 @@ public class EdgeHitProcessorBatchTests {
 
 		BatchOutcome outcome = hitProcessor.processBatch(Arrays.asList(entity1, entity2));
 
-		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
-		assertEquals(2, outcome.getResolvedHeadCount());
+		assertEquals(0, outcome.getRetryDelaySeconds()); // done -> process immediately, no retry delay
+		assertEquals(2, outcome.getRemoveCount());
 	}
 
 	@Test
@@ -159,11 +165,35 @@ public class EdgeHitProcessorBatchTests {
 
 		BatchOutcome outcome = hitProcessor.processBatch(Arrays.asList(experienceEntity, consentEntity));
 
-		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
-		assertEquals(1, outcome.getResolvedHeadCount());
+		assertEquals(0, outcome.getRetryDelaySeconds()); // done -> process immediately, no retry delay
+		assertEquals(1, outcome.getRemoveCount());
 		// Only one network request — for the ExperienceEvent alone; the Consent entity was never sent.
 		verify(mockEdgeNetworkService, times(1))
-			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), any(EdgeNetworkService.ResponseCallback.class));
+			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), ArgumentMatchers.anyBoolean(), any(EdgeNetworkService.ResponseCallback.class));
+	}
+
+	@Test
+	public void testProcessBatch_twoExperienceEvents_differentConfig_resolvesOnlyHead() {
+		// Regression guard: a batched request is built entirely from the head's snapshotted config
+		// (see buildExperienceEventHit) — a single request can only carry one datastream ID/override.
+		// Two events with different configs must not be combined into one request, or the second
+		// would silently lose its own config and be sent under the head's. The run truncates at the
+		// mismatch, same as a Consent boundary; the second entity becomes its own head on a later cycle.
+		mockNetworkReturns(new RetryResult(EdgeNetworkService.NetworkRequestOutcome.SUCCESS, 0));
+
+		Map<String, Object> otherConfig = new HashMap<>(edgeConfig);
+		otherConfig.put("edge.configId", "a-different-config-id");
+
+		DataEntity experienceEntity = buildExperienceEventEntity();
+		DataEntity differentConfigEntity = buildExperienceEventEntity(otherConfig);
+
+		BatchOutcome outcome = hitProcessor.processBatch(Arrays.asList(experienceEntity, differentConfigEntity));
+
+		assertEquals(0, outcome.getRetryDelaySeconds()); // done -> process immediately, no retry delay
+		assertEquals(1, outcome.getRemoveCount());
+		// Only one network request — for the head alone; the differently-configured entity was never sent.
+		verify(mockEdgeNetworkService, times(1))
+			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), ArgumentMatchers.anyBoolean(), any(EdgeNetworkService.ResponseCallback.class));
 	}
 
 	@Test
@@ -173,8 +203,8 @@ public class EdgeHitProcessorBatchTests {
 
 		BatchOutcome outcome = hitProcessor.processBatch(Collections.singletonList(entity));
 
-		assertEquals(BatchOutcome.Kind.RETRY_BATCH, outcome.getKind());
-		assertEquals(5, outcome.getRetryAfterSeconds());
+		assertEquals(0, outcome.getRemoveCount()); // retry -> nothing removed
+		assertEquals(5, outcome.getRetryDelaySeconds());
 		// Waiting events registered
 		verify(mockNetworkResponseHandler, times(1)).addWaitingEvents(anyString(), any());
 	}
@@ -185,16 +215,14 @@ public class EdgeHitProcessorBatchTests {
 
 	@Test
 	public void testProcessBatch_singleExperienceEvent_400_deliversTerminalError() {
-		RetryResult explodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
-		explodeResult.setResponseBody(ERROR_BODY);
-		mockNetworkReturns(explodeResult);
+		mockNetworkReturnsTerminalError(ERROR_BODY);
 
 		DataEntity entity = buildExperienceEventEntity();
 
 		BatchOutcome outcome = hitProcessor.processBatch(Collections.singletonList(entity));
 
 		// Must return DONE (event is fully resolved — error delivered)
-		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+		assertEquals(0, outcome.getRetryDelaySeconds()); // done -> process immediately, no retry delay
 
 		// Capture the requestId assigned during addWaitingEvents so we can assert the same
 		// requestId is passed to processResponseOnError and processResponseOnComplete.
@@ -215,98 +243,47 @@ public class EdgeHitProcessorBatchTests {
 		edgeConfig.put("edge.configId", "test-config-id");
 		edgeConfig.put("edge.batching.enabled", false);
 
-		RetryResult explodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
-		explodeResult.setResponseBody(ERROR_BODY);
-		mockNetworkReturns(explodeResult);
+		mockNetworkReturnsTerminalError(ERROR_BODY);
 
 		DataEntity entity = buildExperienceEventEntity();
 
 		BatchOutcome outcome = hitProcessor.processBatch(Collections.singletonList(entity));
 
-		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+		assertEquals(0, outcome.getRetryDelaySeconds()); // done -> process immediately, no retry delay
 		verify(mockNetworkResponseHandler, times(1)).processResponseOnError(eq(ERROR_BODY), anyString());
 		verify(mockNetworkResponseHandler, times(1)).processResponseOnComplete(anyString());
 	}
 
 	// -------------------------------------------------------------------------
-	// WI-1b: N>1 batch 400 — clean up waiting state, then explode to singles
+	// WI-1b: N>1 batch 400 — clean up waiting state, signal explode(N)
 	// -------------------------------------------------------------------------
 
 	@Test
-	public void testProcessBatch_twoEvents_400_removesWaitingEventsAndExplodes() {
-		// Batch of 2 gets 400; each individual resend succeeds
-		RetryResult explodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
-		explodeResult.setResponseBody(ERROR_BODY);
-		RetryResult successResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.SUCCESS, 0);
-
-		mockNetworkReturnsSequence(explodeResult, successResult, successResult);
+	public void testProcessBatch_twoEvents_400_returnsExplodeCount_cleansUpWaitingEvents() {
+		// Batch of 2 gets 400 — nothing ingested. processBatch no longer resends individually itself;
+		// it reports explode(2) so EdgeBatchingHitQueue can drain the two entities one at a time via
+		// the ordinary single-event path (see EdgeBatchingHitQueueTest for the multi-cycle draining
+		// behavior, including the retry-without-skip guarantee).
+		mockNetworkReturns(new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0));
 
 		DataEntity entity1 = buildExperienceEventEntity();
 		DataEntity entity2 = buildExperienceEventEntity();
 
 		BatchOutcome outcome = hitProcessor.processBatch(Arrays.asList(entity1, entity2));
 
-		// All resolved
-		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+		assertEquals(0, outcome.getRemoveCount());
+		assertEquals(0, outcome.getRetryDelaySeconds());
+		assertEquals(2, outcome.getExplodeCount());
 
-		// 3 network requests: 1 original batch + 2 individual resends
-		verify(mockEdgeNetworkService, times(3))
-			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), any(EdgeNetworkService.ResponseCallback.class));
+		// Exactly one network request — the failed batch attempt; no internal resending.
+		verify(mockEdgeNetworkService, times(1))
+			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), ArgumentMatchers.anyBoolean(), any(EdgeNetworkService.ResponseCallback.class));
 
-		// Original batch waiting events cleaned up (no callbacks, just removal)
+		// Original batch waiting events cleaned up (no callbacks, just removal) — no terminal error
+		// delivered for the batch request ID itself; each event gets its own fresh attempt later.
 		verify(mockNetworkResponseHandler, times(1)).removeWaitingEvents(anyString());
-
-		// No terminal error delivery for the original batch request ID
-		verify(mockNetworkResponseHandler, never()).processResponseOnError(eq(ERROR_BODY), anyString());
-
-		// 3 addWaitingEvents calls: 1 for the original batch + 2 for individual resends
-		verify(mockNetworkResponseHandler, times(3)).addWaitingEvents(anyString(), any());
-	}
-
-	@Test
-	public void testProcessBatch_twoEvents_400_oneIndividualGets400_oneSuceeds() {
-		// Batch of 2 gets 400; first individual gets another 400 (terminal), second succeeds
-		RetryResult batchExplodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
-		batchExplodeResult.setResponseBody(ERROR_BODY);
-		RetryResult singleExplodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
-		singleExplodeResult.setResponseBody(ERROR_BODY);
-		RetryResult successResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.SUCCESS, 0);
-
-		mockNetworkReturnsSequence(batchExplodeResult, singleExplodeResult, successResult);
-
-		DataEntity entity1 = buildExperienceEventEntity();
-		DataEntity entity2 = buildExperienceEventEntity();
-
-		BatchOutcome outcome = hitProcessor.processBatch(Arrays.asList(entity1, entity2));
-
-		// Both resolved (first via terminal error delivery, second via success)
-		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
-
-		// 3 network requests total
-		verify(mockEdgeNetworkService, times(3))
-			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), any(EdgeNetworkService.ResponseCallback.class));
-
-		// Terminal error for the bad single event
-		verify(mockNetworkResponseHandler, times(1)).processResponseOnError(eq(ERROR_BODY), anyString());
-		verify(mockNetworkResponseHandler, times(1)).processResponseOnComplete(anyString());
-	}
-
-	@Test
-	public void testProcessBatch_twoEvents_400_oneIndividualNeedsRetry() {
-		// Batch of 2 gets 400; first individual needs retry
-		RetryResult batchExplodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
-		RetryResult retryResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.RETRY, 10);
-
-		mockNetworkReturnsSequence(batchExplodeResult, retryResult);
-
-		DataEntity entity1 = buildExperienceEventEntity();
-		DataEntity entity2 = buildExperienceEventEntity();
-
-		BatchOutcome outcome = hitProcessor.processBatch(Arrays.asList(entity1, entity2));
-
-		// Nothing resolved before the retry — head entity is the retrying one
-		assertEquals(BatchOutcome.Kind.RETRY_BATCH, outcome.getKind());
-		assertEquals(10, outcome.getRetryAfterSeconds());
+		verify(mockNetworkResponseHandler, never()).processResponseOnError(anyString(), anyString());
+		verify(mockNetworkResponseHandler, never()).processResponseOnComplete(anyString());
 	}
 
 	// -------------------------------------------------------------------------
@@ -315,17 +292,16 @@ public class EdgeHitProcessorBatchTests {
 
 	@Test
 	public void testProcessBatch_consentEvent_400_deliversTerminalError() {
-		RetryResult explodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
-		explodeResult.setResponseBody(ERROR_BODY);
-		mockNetworkReturns(explodeResult);
+		mockNetworkReturnsTerminalError(ERROR_BODY);
 
 		DataEntity entity = buildConsentEventEntity();
 
-		// Consent event goes through processHit → processUpdateConsentEventHit → sendNetworkRequest
-		// sendNetworkRequest must handle EXPLODE_400 as terminal
+		// Consent event goes through processHit → processUpdateConsentEventHit → sendNetworkRequest,
+		// identical to a non-batching build — the real network layer delivers the terminal error via
+		// the injected callback, simulated here the same way.
 		BatchOutcome outcome = hitProcessor.processBatch(Collections.singletonList(entity));
 
-		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+		assertEquals(0, outcome.getRetryDelaySeconds()); // done -> process immediately, no retry delay
 
 		// Consent events register with addWaitingEvent (singular)
 		ArgumentCaptor<String> requestIdCaptor = ArgumentCaptor.forClass(String.class);
@@ -343,9 +319,7 @@ public class EdgeHitProcessorBatchTests {
 	public void testProcessBatch_singleEvent_400_allThreeStepsComplete() {
 		// addWaitingEvents, processResponseOnError, and processResponseOnComplete must all fire
 		// exactly once for a terminal-400 on a batch-of-1.
-		RetryResult explodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
-		explodeResult.setResponseBody(ERROR_BODY);
-		mockNetworkReturns(explodeResult);
+		mockNetworkReturnsTerminalError(ERROR_BODY);
 
 		DataEntity entity = buildExperienceEventEntity();
 		hitProcessor.processBatch(Collections.singletonList(entity));
@@ -360,6 +334,10 @@ public class EdgeHitProcessorBatchTests {
 	// -------------------------------------------------------------------------
 
 	private DataEntity buildExperienceEventEntity() {
+		return buildExperienceEventEntity(edgeConfig);
+	}
+
+	private DataEntity buildExperienceEventEntity(final Map<String, Object> config) {
 		Map<String, Object> xdmData = new HashMap<>();
 		xdmData.put("test", "data");
 		Map<String, Object> eventData = new HashMap<>();
@@ -369,7 +347,7 @@ public class EdgeHitProcessorBatchTests {
 			.setEventData(eventData)
 			.build();
 
-		return new EdgeDataEntity(event, edgeConfig, identityMap).toDataEntity();
+		return new EdgeDataEntity(event, config, identityMap).toDataEntity();
 	}
 
 	private DataEntity buildConsentEventEntity() {
@@ -395,37 +373,37 @@ public class EdgeHitProcessorBatchTests {
 				anyString(),
 				anyString(),
 				ArgumentMatchers.anyMap(),
+				ArgumentMatchers.anyBoolean(),
 				any(EdgeNetworkService.ResponseCallback.class)
 			)
 		)
 			.thenReturn(retryResult);
 	}
 
-	/** Stubs doRequest to return the given results in sequence (last value is repeated if needed). */
-	private void mockNetworkReturnsSequence(final RetryResult first, final RetryResult... rest) {
+	/**
+	 * Stubs a single (non-batch) doRequest call to behave exactly like the real
+	 * {@code EdgeNetworkService.doRequest} does for a single-event terminal error: invokes the
+	 * injected callback's {@code onError} then {@code onComplete} synchronously, and returns a
+	 * {@code DROP} result — mirroring what a real 400 (or any other unrecoverable code) does when
+	 * {@code isBatchRequest} is {@code false}.
+	 */
+	private void mockNetworkReturnsTerminalError(final String errorBody) {
 		when(mockEdgeNetworkService.buildUrl(any(EdgeEndpoint.class), anyString(), anyString()))
 			.thenReturn("https://test.com");
-
-		if (rest == null || rest.length == 0) {
-			when(
-				mockEdgeNetworkService.doRequest(
-					anyString(),
-					anyString(),
-					ArgumentMatchers.anyMap(),
-					any(EdgeNetworkService.ResponseCallback.class)
-				)
+		when(
+			mockEdgeNetworkService.doRequest(
+				anyString(),
+				anyString(),
+				ArgumentMatchers.anyMap(),
+				ArgumentMatchers.anyBoolean(),
+				any(EdgeNetworkService.ResponseCallback.class)
 			)
-				.thenReturn(first);
-		} else {
-			when(
-				mockEdgeNetworkService.doRequest(
-					anyString(),
-					anyString(),
-					ArgumentMatchers.anyMap(),
-					any(EdgeNetworkService.ResponseCallback.class)
-				)
-			)
-				.thenReturn(first, rest);
-		}
+		)
+			.thenAnswer(invocation -> {
+				final EdgeNetworkService.ResponseCallback callback = invocation.getArgument(4);
+				callback.onError(errorBody);
+				callback.onComplete();
+				return new RetryResult(EdgeNetworkService.NetworkRequestOutcome.DROP, 0);
+			});
 	}
 }

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorBatchTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorBatchTests.java
@@ -1,0 +1,396 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.adobe.marketing.mobile.services.DataEntity;
+import com.adobe.marketing.mobile.services.NamedCollection;
+import com.adobe.marketing.mobile.util.MapUtils;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Tests for {@link EdgeHitProcessor#processBatch} — covering the unified single = batch-of-1
+ * path, terminal-400 delivery (regression guard), explosion flow, and Consent/Reset terminal-400.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EdgeHitProcessorBatchTests {
+
+	// Error JSON used as the 400 body in network stubs.
+	private static final String ERROR_BODY =
+		"{\"type\":\"https://ns.adobe.com/aep/errors/EXEG-0305-400\",\"status\":400,\"title\":\"Bad Request\"}";
+
+	private EdgeHitProcessor hitProcessor;
+	private Map<String, Object> edgeConfig;
+
+	private final Map<String, Object> identityMap = new HashMap<String, Object>() {
+		{
+			put(
+				"identityMap",
+				new HashMap<String, Object>() {
+					{
+						put(
+							"ECID",
+							Collections.singletonList(
+								new HashMap<String, Object>() {
+									{
+										put("id", "test-ecid");
+									}
+								}
+							)
+						);
+					}
+				}
+			);
+		}
+	};
+
+	private static MockedStatic<CompletionCallbacksManager> mockCallbacksManagerStatic;
+
+	@Mock
+	EdgeNetworkService mockEdgeNetworkService;
+
+	@Mock
+	NetworkResponseHandler mockNetworkResponseHandler;
+
+	@Mock
+	NamedCollection mockNamedCollection;
+
+	@Mock
+	CompletionCallbacksManager mockCompletionCallbacksManager;
+
+	@Before
+	public void setup() {
+		mockCallbacksManagerStatic = mockStatic(CompletionCallbacksManager.class);
+		mockCallbacksManagerStatic.when(CompletionCallbacksManager::getInstance).thenReturn(mockCompletionCallbacksManager);
+
+		edgeConfig = new HashMap<>();
+		edgeConfig.put("edge.configId", "test-config-id");
+
+		hitProcessor = new EdgeHitProcessor(
+			mockNetworkResponseHandler,
+			mockEdgeNetworkService,
+			mockNamedCollection,
+			null,
+			null
+		);
+	}
+
+	@After
+	public void tearDown() {
+		mockCallbacksManagerStatic.close();
+	}
+
+	// -------------------------------------------------------------------------
+	// WI-1b: single ExperienceEvent goes through the batch path (no redirect)
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testProcessBatch_singleExperienceEvent_success_returnsOutcomeDone() {
+		mockNetworkReturns(new RetryResult(EdgeNetworkService.NetworkRequestOutcome.SUCCESS, 0));
+		DataEntity entity = buildExperienceEventEntity();
+
+		BatchOutcome outcome = hitProcessor.processBatch(Collections.singletonList(entity));
+
+		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+		// Waiting events registered before the network call
+		verify(mockNetworkResponseHandler, times(1)).addWaitingEvents(anyString(), any());
+		// No error path triggered
+		verify(mockNetworkResponseHandler, never()).processResponseOnError(anyString(), anyString());
+		verify(mockNetworkResponseHandler, never()).processResponseOnComplete(anyString());
+	}
+
+	@Test
+	public void testProcessBatch_singleExperienceEvent_retry_returnsOutcomeRetry() {
+		mockNetworkReturns(new RetryResult(EdgeNetworkService.NetworkRequestOutcome.RETRY, 5));
+		DataEntity entity = buildExperienceEventEntity();
+
+		BatchOutcome outcome = hitProcessor.processBatch(Collections.singletonList(entity));
+
+		assertEquals(BatchOutcome.Kind.RETRY_BATCH, outcome.getKind());
+		assertEquals(5, outcome.getRetryAfterSeconds());
+		// Waiting events registered
+		verify(mockNetworkResponseHandler, times(1)).addWaitingEvents(anyString(), any());
+	}
+
+	// -------------------------------------------------------------------------
+	// WI-1b: terminal-400 — regression guard (the core fix)
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testProcessBatch_singleExperienceEvent_400_deliversTerminalError() {
+		RetryResult explodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
+		explodeResult.setResponseBody(ERROR_BODY);
+		mockNetworkReturns(explodeResult);
+
+		DataEntity entity = buildExperienceEventEntity();
+
+		BatchOutcome outcome = hitProcessor.processBatch(Collections.singletonList(entity));
+
+		// Must return DONE (event is fully resolved — error delivered)
+		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+
+		// Capture the requestId assigned during addWaitingEvents so we can assert the same
+		// requestId is passed to processResponseOnError and processResponseOnComplete.
+		ArgumentCaptor<String> requestIdCaptor = ArgumentCaptor.forClass(String.class);
+		verify(mockNetworkResponseHandler, times(1)).addWaitingEvents(requestIdCaptor.capture(), any());
+		final String capturedRequestId = requestIdCaptor.getValue();
+		assertNotNull(capturedRequestId);
+
+		// Terminal-400 must deliver the real error body and fire completion
+		verify(mockNetworkResponseHandler, times(1)).processResponseOnError(eq(ERROR_BODY), eq(capturedRequestId));
+		verify(mockNetworkResponseHandler, times(1)).processResponseOnComplete(eq(capturedRequestId));
+	}
+
+	@Test
+	public void testProcessBatch_singleExperienceEvent_400_batchingFlagOff_deliversTerminalError() {
+		// Explicitly disable batching in config — single-event path must still deliver terminal error
+		edgeConfig = new HashMap<>();
+		edgeConfig.put("edge.configId", "test-config-id");
+		edgeConfig.put("edge.batching.enabled", false);
+
+		RetryResult explodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
+		explodeResult.setResponseBody(ERROR_BODY);
+		mockNetworkReturns(explodeResult);
+
+		DataEntity entity = buildExperienceEventEntity();
+
+		BatchOutcome outcome = hitProcessor.processBatch(Collections.singletonList(entity));
+
+		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+		verify(mockNetworkResponseHandler, times(1)).processResponseOnError(eq(ERROR_BODY), anyString());
+		verify(mockNetworkResponseHandler, times(1)).processResponseOnComplete(anyString());
+	}
+
+	// -------------------------------------------------------------------------
+	// WI-1b: N>1 batch 400 — clean up waiting state, then explode to singles
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testProcessBatch_twoEvents_400_removesWaitingEventsAndExplodes() {
+		// Batch of 2 gets 400; each individual resend succeeds
+		RetryResult explodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
+		explodeResult.setResponseBody(ERROR_BODY);
+		RetryResult successResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.SUCCESS, 0);
+
+		mockNetworkReturnsSequence(explodeResult, successResult, successResult);
+
+		DataEntity entity1 = buildExperienceEventEntity();
+		DataEntity entity2 = buildExperienceEventEntity();
+
+		BatchOutcome outcome = hitProcessor.processBatch(Arrays.asList(entity1, entity2));
+
+		// All resolved
+		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+
+		// 3 network requests: 1 original batch + 2 individual resends
+		verify(mockEdgeNetworkService, times(3))
+			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), any(EdgeNetworkService.ResponseCallback.class));
+
+		// Original batch waiting events cleaned up (no callbacks, just removal)
+		verify(mockNetworkResponseHandler, times(1)).removeWaitingEvents(anyString());
+
+		// No terminal error delivery for the original batch request ID
+		verify(mockNetworkResponseHandler, never()).processResponseOnError(eq(ERROR_BODY), anyString());
+
+		// 3 addWaitingEvents calls: 1 for the original batch + 2 for individual resends
+		verify(mockNetworkResponseHandler, times(3)).addWaitingEvents(anyString(), any());
+	}
+
+	@Test
+	public void testProcessBatch_twoEvents_400_oneIndividualGets400_oneSuceeds() {
+		// Batch of 2 gets 400; first individual gets another 400 (terminal), second succeeds
+		RetryResult batchExplodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
+		batchExplodeResult.setResponseBody(ERROR_BODY);
+		RetryResult singleExplodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
+		singleExplodeResult.setResponseBody(ERROR_BODY);
+		RetryResult successResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.SUCCESS, 0);
+
+		mockNetworkReturnsSequence(batchExplodeResult, singleExplodeResult, successResult);
+
+		DataEntity entity1 = buildExperienceEventEntity();
+		DataEntity entity2 = buildExperienceEventEntity();
+
+		BatchOutcome outcome = hitProcessor.processBatch(Arrays.asList(entity1, entity2));
+
+		// Both resolved (first via terminal error delivery, second via success)
+		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+
+		// 3 network requests total
+		verify(mockEdgeNetworkService, times(3))
+			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), any(EdgeNetworkService.ResponseCallback.class));
+
+		// Terminal error for the bad single event
+		verify(mockNetworkResponseHandler, times(1)).processResponseOnError(eq(ERROR_BODY), anyString());
+		verify(mockNetworkResponseHandler, times(1)).processResponseOnComplete(anyString());
+	}
+
+	@Test
+	public void testProcessBatch_twoEvents_400_oneIndividualNeedsRetry() {
+		// Batch of 2 gets 400; first individual needs retry
+		RetryResult batchExplodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
+		RetryResult retryResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.RETRY, 10);
+
+		mockNetworkReturnsSequence(batchExplodeResult, retryResult);
+
+		DataEntity entity1 = buildExperienceEventEntity();
+		DataEntity entity2 = buildExperienceEventEntity();
+
+		BatchOutcome outcome = hitProcessor.processBatch(Arrays.asList(entity1, entity2));
+
+		// Nothing resolved before the retry — head entity is the retrying one
+		assertEquals(BatchOutcome.Kind.RETRY_BATCH, outcome.getKind());
+		assertEquals(10, outcome.getRetryAfterSeconds());
+	}
+
+	// -------------------------------------------------------------------------
+	// WI-1d: Consent/Reset terminal-400 via sendNetworkRequest
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testProcessBatch_consentEvent_400_deliversTerminalError() {
+		RetryResult explodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
+		explodeResult.setResponseBody(ERROR_BODY);
+		mockNetworkReturns(explodeResult);
+
+		DataEntity entity = buildConsentEventEntity();
+
+		// Consent event goes through processHit → processUpdateConsentEventHit → sendNetworkRequest
+		// sendNetworkRequest must handle EXPLODE_400 as terminal
+		BatchOutcome outcome = hitProcessor.processBatch(Collections.singletonList(entity));
+
+		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+
+		// Consent events register with addWaitingEvent (singular)
+		ArgumentCaptor<String> requestIdCaptor = ArgumentCaptor.forClass(String.class);
+		verify(mockNetworkResponseHandler, times(1)).addWaitingEvent(requestIdCaptor.capture(), any());
+
+		verify(mockNetworkResponseHandler, times(1)).processResponseOnError(eq(ERROR_BODY), eq(requestIdCaptor.getValue()));
+		verify(mockNetworkResponseHandler, times(1)).processResponseOnComplete(eq(requestIdCaptor.getValue()));
+	}
+
+	// -------------------------------------------------------------------------
+	// WI-1e: no waiting-event / callback leak after terminal and batch flows
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testProcessBatch_singleEvent_400_allThreeStepsComplete() {
+		// addWaitingEvents, processResponseOnError, and processResponseOnComplete must all fire
+		// exactly once for a terminal-400 on a batch-of-1.
+		RetryResult explodeResult = new RetryResult(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, 0);
+		explodeResult.setResponseBody(ERROR_BODY);
+		mockNetworkReturns(explodeResult);
+
+		DataEntity entity = buildExperienceEventEntity();
+		hitProcessor.processBatch(Collections.singletonList(entity));
+
+		verify(mockNetworkResponseHandler, times(1)).addWaitingEvents(anyString(), any());
+		verify(mockNetworkResponseHandler, times(1)).processResponseOnError(anyString(), anyString());
+		verify(mockNetworkResponseHandler, times(1)).processResponseOnComplete(anyString());
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private DataEntity buildExperienceEventEntity() {
+		Map<String, Object> xdmData = new HashMap<>();
+		xdmData.put("test", "data");
+		Map<String, Object> eventData = new HashMap<>();
+		eventData.put("xdm", xdmData);
+
+		Event event = new Event.Builder("test-event", EventType.EDGE, EventSource.REQUEST_CONTENT)
+			.setEventData(eventData)
+			.build();
+
+		return new EdgeDataEntity(event, edgeConfig, identityMap).toDataEntity();
+	}
+
+	private DataEntity buildConsentEventEntity() {
+		Map<String, Object> collectMap = new HashMap<>();
+		collectMap.put("val", "y");
+		Map<String, Object> consentsMap = new HashMap<>();
+		consentsMap.put("collect", collectMap);
+		Map<String, Object> eventData = new HashMap<>();
+		eventData.put("consents", consentsMap);
+
+		Event event = new Event.Builder("test-consent", EventType.EDGE, EventSource.UPDATE_CONSENT)
+			.setEventData(eventData)
+			.build();
+
+		return new EdgeDataEntity(event, edgeConfig, identityMap).toDataEntity();
+	}
+
+	private void mockNetworkReturns(final RetryResult retryResult) {
+		when(mockEdgeNetworkService.buildUrl(any(EdgeEndpoint.class), anyString(), anyString()))
+			.thenReturn("https://test.com");
+		when(
+			mockEdgeNetworkService.doRequest(
+				anyString(),
+				anyString(),
+				ArgumentMatchers.anyMap(),
+				any(EdgeNetworkService.ResponseCallback.class)
+			)
+		)
+			.thenReturn(retryResult);
+	}
+
+	/** Stubs doRequest to return the given results in sequence (last value is repeated if needed). */
+	private void mockNetworkReturnsSequence(final RetryResult first, final RetryResult... rest) {
+		when(mockEdgeNetworkService.buildUrl(any(EdgeEndpoint.class), anyString(), anyString()))
+			.thenReturn("https://test.com");
+
+		if (rest == null || rest.length == 0) {
+			when(
+				mockEdgeNetworkService.doRequest(
+					anyString(),
+					anyString(),
+					ArgumentMatchers.anyMap(),
+					any(EdgeNetworkService.ResponseCallback.class)
+				)
+			)
+				.thenReturn(first);
+		} else {
+			when(
+				mockEdgeNetworkService.doRequest(
+					anyString(),
+					anyString(),
+					ArgumentMatchers.anyMap(),
+					any(EdgeNetworkService.ResponseCallback.class)
+				)
+			)
+				.thenReturn(first, rest);
+		}
+	}
+}

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorBatchTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorBatchTests.java
@@ -97,6 +97,7 @@ public class EdgeHitProcessorBatchTests {
 
 		edgeConfig = new HashMap<>();
 		edgeConfig.put("edge.configId", "test-config-id");
+		edgeConfig.put("edge.batching.eventNameAllowlist", Collections.singletonList("test-event"));
 
 		hitProcessor = new EdgeHitProcessor(
 			mockNetworkResponseHandler,

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorBatchTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorBatchTests.java
@@ -124,11 +124,45 @@ public class EdgeHitProcessorBatchTests {
 		BatchOutcome outcome = hitProcessor.processBatch(Collections.singletonList(entity));
 
 		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+		// Regression guard: DONE must report exactly how many entities were resolved, so the queue
+		// removes only those — never a stale/full peeked-window count.
+		assertEquals(1, outcome.getResolvedHeadCount());
 		// Waiting events registered before the network call
 		verify(mockNetworkResponseHandler, times(1)).addWaitingEvents(anyString(), any());
 		// No error path triggered
 		verify(mockNetworkResponseHandler, never()).processResponseOnError(anyString(), anyString());
 		verify(mockNetworkResponseHandler, never()).processResponseOnComplete(anyString());
+	}
+
+	@Test
+	public void testProcessBatch_twoExperienceEvents_success_resolvedHeadCountIsTwo() {
+		mockNetworkReturns(new RetryResult(EdgeNetworkService.NetworkRequestOutcome.SUCCESS, 0));
+		DataEntity entity1 = buildExperienceEventEntity();
+		DataEntity entity2 = buildExperienceEventEntity();
+
+		BatchOutcome outcome = hitProcessor.processBatch(Arrays.asList(entity1, entity2));
+
+		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+		assertEquals(2, outcome.getResolvedHeadCount());
+	}
+
+	@Test
+	public void testProcessBatch_experienceEventFollowedByConsent_resolvesOnlyLeadingExperienceRun() {
+		// Regression guard: a mixed window (ExperienceEvent then Consent) must truncate the batch at
+		// the Consent boundary and report a resolvedHeadCount matching only the entities actually
+		// sent (1), not the full peeked window (2) — otherwise EdgeBatchingHitQueue's DONE handling
+		// would remove the untouched Consent entity from the queue without ever processing it.
+		mockNetworkReturns(new RetryResult(EdgeNetworkService.NetworkRequestOutcome.SUCCESS, 0));
+		DataEntity experienceEntity = buildExperienceEventEntity();
+		DataEntity consentEntity = buildConsentEventEntity();
+
+		BatchOutcome outcome = hitProcessor.processBatch(Arrays.asList(experienceEntity, consentEntity));
+
+		assertEquals(BatchOutcome.Kind.DONE, outcome.getKind());
+		assertEquals(1, outcome.getResolvedHeadCount());
+		// Only one network request — for the ExperienceEvent alone; the Consent entity was never sent.
+		verify(mockEdgeNetworkService, times(1))
+			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), any(EdgeNetworkService.ResponseCallback.class));
 	}
 
 	@Test

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorBatchTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorBatchTests.java
@@ -1,5 +1,5 @@
 /*
-  Copyright 2024 Adobe. All rights reserved.
+  Copyright 2026 Adobe. All rights reserved.
   This file is licensed to you under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License. You may obtain a copy
   of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorBatchTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorBatchTests.java
@@ -24,11 +24,9 @@ import static org.mockito.Mockito.when;
 
 import com.adobe.marketing.mobile.services.DataEntity;
 import com.adobe.marketing.mobile.services.NamedCollection;
-import com.adobe.marketing.mobile.util.MapUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
@@ -99,19 +97,16 @@ public class EdgeHitProcessorBatchTests {
 	@Before
 	public void setup() {
 		mockCallbacksManagerStatic = mockStatic(CompletionCallbacksManager.class);
-		mockCallbacksManagerStatic.when(CompletionCallbacksManager::getInstance).thenReturn(mockCompletionCallbacksManager);
+		mockCallbacksManagerStatic
+			.when(CompletionCallbacksManager::getInstance)
+			.thenReturn(mockCompletionCallbacksManager);
 
 		edgeConfig = new HashMap<>();
 		edgeConfig.put("edge.configId", "test-config-id");
 		edgeConfig.put("edge.batching.eventNameAllowlist", Collections.singletonList("test-event"));
 
-		hitProcessor = new EdgeHitProcessor(
-			mockNetworkResponseHandler,
-			mockEdgeNetworkService,
-			mockNamedCollection,
-			null,
-			null
-		);
+		hitProcessor =
+			new EdgeHitProcessor(mockNetworkResponseHandler, mockEdgeNetworkService, mockNamedCollection, null, null);
 	}
 
 	@After
@@ -169,7 +164,13 @@ public class EdgeHitProcessorBatchTests {
 		assertEquals(1, outcome.getRemoveCount());
 		// Only one network request — for the ExperienceEvent alone; the Consent entity was never sent.
 		verify(mockEdgeNetworkService, times(1))
-			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), ArgumentMatchers.anyBoolean(), any(EdgeNetworkService.ResponseCallback.class));
+			.doRequest(
+				anyString(),
+				anyString(),
+				ArgumentMatchers.anyMap(),
+				ArgumentMatchers.anyBoolean(),
+				any(EdgeNetworkService.ResponseCallback.class)
+			);
 	}
 
 	@Test
@@ -193,7 +194,13 @@ public class EdgeHitProcessorBatchTests {
 		assertEquals(1, outcome.getRemoveCount());
 		// Only one network request — for the head alone; the differently-configured entity was never sent.
 		verify(mockEdgeNetworkService, times(1))
-			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), ArgumentMatchers.anyBoolean(), any(EdgeNetworkService.ResponseCallback.class));
+			.doRequest(
+				anyString(),
+				anyString(),
+				ArgumentMatchers.anyMap(),
+				ArgumentMatchers.anyBoolean(),
+				any(EdgeNetworkService.ResponseCallback.class)
+			);
 	}
 
 	@Test
@@ -277,7 +284,13 @@ public class EdgeHitProcessorBatchTests {
 
 		// Exactly one network request — the failed batch attempt; no internal resending.
 		verify(mockEdgeNetworkService, times(1))
-			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), ArgumentMatchers.anyBoolean(), any(EdgeNetworkService.ResponseCallback.class));
+			.doRequest(
+				anyString(),
+				anyString(),
+				ArgumentMatchers.anyMap(),
+				ArgumentMatchers.anyBoolean(),
+				any(EdgeNetworkService.ResponseCallback.class)
+			);
 
 		// Original batch waiting events cleaned up (no callbacks, just removal) — no terminal error
 		// delivered for the batch request ID itself; each event gets its own fresh attempt later.
@@ -307,7 +320,8 @@ public class EdgeHitProcessorBatchTests {
 		ArgumentCaptor<String> requestIdCaptor = ArgumentCaptor.forClass(String.class);
 		verify(mockNetworkResponseHandler, times(1)).addWaitingEvent(requestIdCaptor.capture(), any());
 
-		verify(mockNetworkResponseHandler, times(1)).processResponseOnError(eq(ERROR_BODY), eq(requestIdCaptor.getValue()));
+		verify(mockNetworkResponseHandler, times(1))
+			.processResponseOnError(eq(ERROR_BODY), eq(requestIdCaptor.getValue()));
 		verify(mockNetworkResponseHandler, times(1)).processResponseOnComplete(eq(requestIdCaptor.getValue()));
 	}
 

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorTests.java
@@ -23,9 +23,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -428,14 +429,24 @@ public class EdgeHitProcessorTests {
 				anyString(),
 				anyString(),
 				ArgumentMatchers.anyMap(),
+				eq(false),
 				any(EdgeNetworkService.ResponseCallback.class)
 			)
 		)
 			.thenReturn(new RetryResult(EdgeNetworkService.Retry.NO));
 
-		// test
-		doCallRealMethod().when(mockNetworkResponseHandler).processResponseOnComplete(anyString());
-		when(mockNetworkResponseHandler.removeWaitingEvents(hit.getRequestId()))
+		// test — a real (spied) NetworkResponseHandler, so processResponseOnComplete's cleanup logic
+		// (nextCompletionIndex, etc.) runs against a properly-constructed instance rather than an
+		// uninitialized mock.
+		final NetworkResponseHandler realNetworkResponseHandler = newRealNetworkResponseHandler();
+		final EdgeHitProcessor localHitProcessor = new EdgeHitProcessor(
+			realNetworkResponseHandler,
+			mockEdgeNetworkService,
+			mockNamedCollection,
+			null,
+			null
+		);
+		when(realNetworkResponseHandler.removeWaitingEvents(hit.getRequestId()))
 			.thenReturn(
 				new ArrayList<Event>() {
 					{
@@ -444,26 +455,24 @@ public class EdgeHitProcessorTests {
 					}
 				}
 			);
-		hitProcessor.sendNetworkRequest(null, hit, new HashMap<String, String>());
+		localHitProcessor.sendNetworkRequest(null, hit, new HashMap<String, String>());
 
 		// verify
 		ArgumentCaptor<EdgeNetworkService.ResponseCallback> callbackArgCaptor = ArgumentCaptor.forClass(
 			EdgeNetworkService.ResponseCallback.class
 		);
-		verify(mockEdgeNetworkService);
-		mockEdgeNetworkService.doRequest(
-			anyString(),
-			anyString(),
-			ArgumentMatchers.anyMap(),
-			callbackArgCaptor.capture()
-		);
+		verify(mockEdgeNetworkService)
+			.doRequest(
+				anyString(),
+				anyString(),
+				ArgumentMatchers.anyMap(),
+				eq(false),
+				callbackArgCaptor.capture()
+			);
 		callbackArgCaptor.getValue().onComplete();
-		verify(mockNetworkResponseHandler);
-		mockNetworkResponseHandler.removeWaitingEvents(hit.getRequestId());
-		verify(mockResponseCallbackHandler, times(1));
-		mockResponseCallbackHandler.unregisterCallback(mockEvent1.getUniqueIdentifier());
-		verify(mockResponseCallbackHandler, times(1));
-		mockResponseCallbackHandler.unregisterCallback(mockEvent2.getUniqueIdentifier());
+		verify(realNetworkResponseHandler).removeWaitingEvents(hit.getRequestId());
+		verify(mockResponseCallbackHandler, times(1)).unregisterCallback(mockEvent1.getUniqueIdentifier());
+		verify(mockResponseCallbackHandler, times(1)).unregisterCallback(mockEvent2.getUniqueIdentifier());
 	}
 
 	@Test
@@ -485,33 +494,41 @@ public class EdgeHitProcessorTests {
 				anyString(),
 				anyString(),
 				ArgumentMatchers.anyMap(),
+				eq(false),
 				any(EdgeNetworkService.ResponseCallback.class)
 			)
 		)
 			.thenReturn(new RetryResult(EdgeNetworkService.Retry.NO));
 
-		// test
-		doCallRealMethod().when(mockNetworkResponseHandler).processResponseOnComplete(anyString());
-		when(mockNetworkResponseHandler.removeWaitingEvents(hit.getRequestId())).thenReturn(null);
+		// test — a real (spied) NetworkResponseHandler, so processResponseOnComplete's cleanup logic
+		// runs against a properly-constructed instance rather than an uninitialized mock.
+		final NetworkResponseHandler realNetworkResponseHandler = newRealNetworkResponseHandler();
+		final EdgeHitProcessor localHitProcessor = new EdgeHitProcessor(
+			realNetworkResponseHandler,
+			mockEdgeNetworkService,
+			mockNamedCollection,
+			null,
+			null
+		);
+		when(realNetworkResponseHandler.removeWaitingEvents(hit.getRequestId())).thenReturn(null);
 
-		hitProcessor.sendNetworkRequest(null, hit, new HashMap<String, String>());
+		localHitProcessor.sendNetworkRequest(null, hit, new HashMap<String, String>());
 
 		// verify
 		ArgumentCaptor<EdgeNetworkService.ResponseCallback> callbackArgCaptor = ArgumentCaptor.forClass(
 			EdgeNetworkService.ResponseCallback.class
 		);
-		verify(mockEdgeNetworkService);
-		mockEdgeNetworkService.doRequest(
-			anyString(),
-			anyString(),
-			ArgumentMatchers.anyMap(),
-			callbackArgCaptor.capture()
-		);
+		verify(mockEdgeNetworkService)
+			.doRequest(
+				anyString(),
+				anyString(),
+				ArgumentMatchers.anyMap(),
+				eq(false),
+				callbackArgCaptor.capture()
+			);
 		callbackArgCaptor.getValue().onComplete(); // simulates this is done by the doRequest method
-		verify(mockNetworkResponseHandler);
-		mockNetworkResponseHandler.removeWaitingEvents(hit.getRequestId());
-		verify(mockResponseCallbackHandler, never());
-		mockResponseCallbackHandler.unregisterCallback(anyString());
+		verify(realNetworkResponseHandler).removeWaitingEvents(hit.getRequestId());
+		verify(mockResponseCallbackHandler, never()).unregisterCallback(anyString());
 	}
 
 	@Test
@@ -532,8 +549,17 @@ public class EdgeHitProcessorTests {
 		);
 		final EdgeHit hit = new EdgeHit(configId, requestBody, endpoint);
 		when(mockEdgeNetworkService.buildUrl(endpoint, configId, hit.getRequestId())).thenReturn("https://test.com");
-		doCallRealMethod().when(mockNetworkResponseHandler).processResponseOnComplete(anyString());
-		when(mockNetworkResponseHandler.removeWaitingEvents(hit.getRequestId()))
+		// A real (spied) NetworkResponseHandler, so processResponseOnComplete's cleanup logic runs
+		// against a properly-constructed instance rather than an uninitialized mock.
+		final NetworkResponseHandler realNetworkResponseHandler = newRealNetworkResponseHandler();
+		final EdgeHitProcessor localHitProcessor = new EdgeHitProcessor(
+			realNetworkResponseHandler,
+			mockEdgeNetworkService,
+			mockNamedCollection,
+			null,
+			null
+		);
+		when(realNetworkResponseHandler.removeWaitingEvents(hit.getRequestId()))
 			.thenReturn(
 				new ArrayList<Event>() {
 					{
@@ -551,25 +577,25 @@ public class EdgeHitProcessorTests {
 				anyString(),
 				anyString(),
 				ArgumentMatchers.anyMap(),
+				eq(false),
 				any(EdgeNetworkService.ResponseCallback.class)
 			)
 		)
 			.thenReturn(new RetryResult(EdgeNetworkService.Retry.NO, 1));
-		hitProcessor.sendNetworkRequest(null, hit, new HashMap<String, String>());
+		localHitProcessor.sendNetworkRequest(null, hit, new HashMap<String, String>());
 
 		// verify
-		verify(mockEdgeNetworkService, times(1));
-		mockEdgeNetworkService.doRequest(
-			anyString(),
-			anyString(),
-			ArgumentMatchers.anyMap(),
-			callbackArgCaptor.capture()
-		);
+		verify(mockEdgeNetworkService, times(1))
+			.doRequest(
+				anyString(),
+				anyString(),
+				ArgumentMatchers.anyMap(),
+				eq(false),
+				callbackArgCaptor.capture()
+			);
 		callbackArgCaptor.getValue().onComplete();
-		verify(mockNetworkResponseHandler);
-		mockNetworkResponseHandler.removeWaitingEvents(hit.getRequestId());
-		verify(mockResponseCallbackHandler, times(1));
-		mockResponseCallbackHandler.unregisterCallback(mockEvent1.getUniqueIdentifier());
+		verify(realNetworkResponseHandler).removeWaitingEvents(hit.getRequestId());
+		verify(mockResponseCallbackHandler, times(1)).unregisterCallback(mockEvent1.getUniqueIdentifier());
 	}
 
 	@Test
@@ -596,6 +622,7 @@ public class EdgeHitProcessorTests {
 				anyString(),
 				anyString(),
 				ArgumentMatchers.anyMap(),
+				eq(false),
 				any(EdgeNetworkService.ResponseCallback.class)
 			);
 
@@ -625,6 +652,7 @@ public class EdgeHitProcessorTests {
 				anyString(),
 				anyString(),
 				ArgumentMatchers.anyMap(),
+				eq(false),
 				any(EdgeNetworkService.ResponseCallback.class)
 			);
 
@@ -1176,6 +1204,7 @@ public class EdgeHitProcessorTests {
 				anyString(),
 				payloadCaptor.capture(),
 				ArgumentMatchers.anyMap(),
+				eq(false),
 				any(EdgeNetworkService.ResponseCallback.class)
 			);
 
@@ -1212,6 +1241,7 @@ public class EdgeHitProcessorTests {
 				anyString(),
 				payloadCaptor.capture(),
 				ArgumentMatchers.anyMap(),
+				eq(false),
 				any(EdgeNetworkService.ResponseCallback.class)
 			);
 
@@ -1269,6 +1299,7 @@ public class EdgeHitProcessorTests {
 				anyString(),
 				payloadCaptor.capture(),
 				ArgumentMatchers.anyMap(),
+				eq(false),
 				any(EdgeNetworkService.ResponseCallback.class)
 			);
 
@@ -1353,6 +1384,18 @@ public class EdgeHitProcessorTests {
 
 	//************************************************** Utils **************************************************
 
+	/**
+	 * A real, properly-constructed {@link NetworkResponseHandler} wrapped in a spy, for tests that
+	 * need {@code processResponseOnComplete}'s actual cleanup logic to run (not just be stubbed) —
+	 * a bare {@code @Mock} never runs field initializers (e.g. {@code nextCompletionIndex}), so
+	 * driving the real method body on one via {@code doCallRealMethod()} NPEs. Spying a real instance
+	 * avoids that while still allowing individual methods (e.g. {@code removeWaitingEvents}) to be
+	 * stubbed as needed.
+	 */
+	private NetworkResponseHandler newRealNetworkResponseHandler() {
+		return spy(new NetworkResponseHandler(mockNamedCollection, null));
+	}
+
 	void assertProcessHitResult(@NotNull final DataEntity entity, final boolean expectedHitProcessingResult) {
 		hitProcessor.processHit(
 			entity,
@@ -1428,7 +1471,7 @@ public class EdgeHitProcessorTests {
 				EdgeNetworkService.ResponseCallback.class
 			);
 			verify(mockEdgeNetworkService, times(1))
-				.doRequest(anyString(), anyString(), headersCaptor.capture(), callbackArgCaptor.capture());
+				.doRequest(anyString(), anyString(), headersCaptor.capture(), eq(false), callbackArgCaptor.capture());
 
 			if (withHeaders == null || withHeaders.isEmpty()) {
 				assertEquals(0, headersCaptor.getValue().size());
@@ -1443,6 +1486,7 @@ public class EdgeHitProcessorTests {
 					anyString(),
 					anyString(),
 					ArgumentMatchers.anyMap(),
+					eq(false),
 					any(EdgeNetworkService.ResponseCallback.class)
 				);
 		}
@@ -1469,6 +1513,7 @@ public class EdgeHitProcessorTests {
 				anyString(),
 				anyString(),
 				ArgumentMatchers.anyMap(),
+				eq(false),
 				any(EdgeNetworkService.ResponseCallback.class)
 			)
 		)

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeHitProcessorTests.java
@@ -462,13 +462,7 @@ public class EdgeHitProcessorTests {
 			EdgeNetworkService.ResponseCallback.class
 		);
 		verify(mockEdgeNetworkService)
-			.doRequest(
-				anyString(),
-				anyString(),
-				ArgumentMatchers.anyMap(),
-				eq(false),
-				callbackArgCaptor.capture()
-			);
+			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), eq(false), callbackArgCaptor.capture());
 		callbackArgCaptor.getValue().onComplete();
 		verify(realNetworkResponseHandler).removeWaitingEvents(hit.getRequestId());
 		verify(mockResponseCallbackHandler, times(1)).unregisterCallback(mockEvent1.getUniqueIdentifier());
@@ -519,13 +513,7 @@ public class EdgeHitProcessorTests {
 			EdgeNetworkService.ResponseCallback.class
 		);
 		verify(mockEdgeNetworkService)
-			.doRequest(
-				anyString(),
-				anyString(),
-				ArgumentMatchers.anyMap(),
-				eq(false),
-				callbackArgCaptor.capture()
-			);
+			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), eq(false), callbackArgCaptor.capture());
 		callbackArgCaptor.getValue().onComplete(); // simulates this is done by the doRequest method
 		verify(realNetworkResponseHandler).removeWaitingEvents(hit.getRequestId());
 		verify(mockResponseCallbackHandler, never()).unregisterCallback(anyString());
@@ -586,13 +574,7 @@ public class EdgeHitProcessorTests {
 
 		// verify
 		verify(mockEdgeNetworkService, times(1))
-			.doRequest(
-				anyString(),
-				anyString(),
-				ArgumentMatchers.anyMap(),
-				eq(false),
-				callbackArgCaptor.capture()
-			);
+			.doRequest(anyString(), anyString(), ArgumentMatchers.anyMap(), eq(false), callbackArgCaptor.capture());
 		callbackArgCaptor.getValue().onComplete();
 		verify(realNetworkResponseHandler).removeWaitingEvents(hit.getRequestId());
 		verify(mockResponseCallbackHandler, times(1)).unregisterCallback(mockEvent1.getUniqueIdentifier());

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
@@ -628,7 +628,6 @@ public class EdgeNetworkServiceTest {
 		assertNull(result.onResponseCallback[0]);
 		assertNull(result.onErrorCallback[0]);
 		assertNull(result.onCompleteCallback[0]);
-		assertGenericJsonError(errorStr, DEFAULT_ERROR_NAMESPACE, result.retryResult.getResponseBody());
 	}
 
 	@Test

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
@@ -620,7 +620,10 @@ public class EdgeNetworkServiceTest {
 
 		// verify - nothing was ingested; onError/onComplete are suppressed so the caller can resend
 		// each event individually without a phantom error/complete firing first.
-		assertEquals(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, result.retryResult.getNetworkRequestOutcome());
+		assertEquals(
+			EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400,
+			result.retryResult.getNetworkRequestOutcome()
+		);
 		assertEquals(EdgeNetworkService.Retry.NO, result.retryResult.getShouldRetry());
 		assertNull(result.onResponseCallback[0]);
 		assertNull(result.onErrorCallback[0]);

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EdgeNetworkServiceTest.java
@@ -585,6 +585,50 @@ public class EdgeNetworkServiceTest {
 	}
 
 	@Test
+	public void testDoRequest_whenConnection_400ResponseCode_NotBatchRequest_TreatedAsUnrecoverable() {
+		// setup
+		final String jsonRequest = "{}";
+		final String errorStr = "Bad Request";
+		MockConnection mockConnection = new MockConnection(400, null, errorStr, null);
+		mockNetworkService.setDefaultResponse(mockConnection);
+		networkService = new EdgeNetworkService(mockNetworkService);
+
+		// test - single-event (non-batch) request, identical to a build without batching
+		DoRequestResult result = doRequestSync(TEST_URL, jsonRequest, false);
+
+		// verify - a 400 for a single event behaves exactly like any other unrecoverable code:
+		// onError fires (via handleError), onComplete fires, no EXPLODE_400 classification.
+		assertEquals(EdgeNetworkService.NetworkRequestOutcome.DROP, result.retryResult.getNetworkRequestOutcome());
+		assertEquals(EdgeNetworkService.Retry.NO, result.retryResult.getShouldRetry());
+		assertNull(result.onResponseCallback[0]);
+		assertNotNull(result.onErrorCallback[0]);
+		assertNotNull(result.onCompleteCallback[0]);
+		assertGenericJsonError(errorStr, DEFAULT_ERROR_NAMESPACE, result.onErrorCallback[1]);
+	}
+
+	@Test
+	public void testDoRequest_whenConnection_400ResponseCode_BatchRequest_ReturnsExplode400() {
+		// setup
+		final String jsonRequest = "{}";
+		final String errorStr = "Bad Request";
+		MockConnection mockConnection = new MockConnection(400, null, errorStr, null);
+		mockNetworkService.setDefaultResponse(mockConnection);
+		networkService = new EdgeNetworkService(mockNetworkService);
+
+		// test - a real multi-event batch, which the caller is prepared to explode into resends
+		DoRequestResult result = doRequestSync(TEST_URL, jsonRequest, true);
+
+		// verify - nothing was ingested; onError/onComplete are suppressed so the caller can resend
+		// each event individually without a phantom error/complete firing first.
+		assertEquals(EdgeNetworkService.NetworkRequestOutcome.EXPLODE_400, result.retryResult.getNetworkRequestOutcome());
+		assertEquals(EdgeNetworkService.Retry.NO, result.retryResult.getShouldRetry());
+		assertNull(result.onResponseCallback[0]);
+		assertNull(result.onErrorCallback[0]);
+		assertNull(result.onCompleteCallback[0]);
+		assertGenericJsonError(errorStr, DEFAULT_ERROR_NAMESPACE, result.retryResult.getResponseBody());
+	}
+
+	@Test
 	public void testHandleStreamingResponse_NullParams() {
 		// setup
 		networkService = new EdgeNetworkService(mockNetworkService);
@@ -955,6 +999,10 @@ public class EdgeNetworkServiceTest {
 	 * onError callback if called and the value.
 	 */
 	private DoRequestResult doRequestSync(final String url, final String body) {
+		return doRequestSync(url, body, false);
+	}
+
+	private DoRequestResult doRequestSync(final String url, final String body, final boolean isBatchRequest) {
 		final DoRequestResult result = new DoRequestResult();
 		final Map<String, String> requestProperty = new HashMap<>();
 		result.retryResult =
@@ -962,6 +1010,7 @@ public class EdgeNetworkServiceTest {
 				url,
 				body,
 				requestProperty,
+				isBatchRequest,
 				new EdgeNetworkService.ResponseCallback() {
 					@Override
 					public void onResponse(final String jsonResponse) {

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EventUtilsTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EventUtilsTests.java
@@ -12,13 +12,32 @@
 package com.adobe.marketing.mobile;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mockStatic;
 
 import com.adobe.marketing.mobile.util.JSONAsserts;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 
 public class EventUtilsTests {
+
+	private MockedStatic<EdgeBundledBatchingConfig> mockBundledBatchingConfigStatic;
+
+	@Before
+	public void setup() {
+		mockBundledBatchingConfigStatic = mockStatic(EdgeBundledBatchingConfig.class);
+		mockBundledBatchingConfigStatic.when(EdgeBundledBatchingConfig::get).thenReturn(Collections.emptyMap());
+	}
+
+	@After
+	public void tearDown() {
+		mockBundledBatchingConfigStatic.close();
+	}
 
 	@Test
 	public void testGetEdgeConfiguration_allValidConfigs() {
@@ -193,5 +212,79 @@ public class EventUtilsTests {
 		);
 
 		assertEquals(0, result.size());
+	}
+
+	// -------------------------------------------------------------------------
+	// Bundled batching config fallback (per-key)
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testGetEdgeConfiguration_batchingEnabled_presentInSharedState_bundledConfigIgnored() {
+		mockBundledBatchingConfigStatic
+			.when(EdgeBundledBatchingConfig::get)
+			.thenReturn(Collections.singletonMap("edge.batching.enabled", false));
+
+		Map<String, Object> result = EventUtils.getEdgeConfiguration(
+			new HashMap<String, Object>() {
+				{
+					put("edge.batching.enabled", true);
+				}
+			}
+		);
+
+		assertEquals(true, result.get("edge.batching.enabled"));
+	}
+
+	@Test
+	public void testGetEdgeConfiguration_batchingEnabled_absentFromSharedState_usesBundledConfig() {
+		mockBundledBatchingConfigStatic
+			.when(EdgeBundledBatchingConfig::get)
+			.thenReturn(Collections.singletonMap("edge.batching.enabled", true));
+
+		Map<String, Object> result = EventUtils.getEdgeConfiguration(new HashMap<>());
+
+		assertEquals(true, result.get("edge.batching.enabled"));
+	}
+
+	@Test
+	public void testGetEdgeConfiguration_batchingEnabled_absentFromBoth_keyNotInResult() {
+		Map<String, Object> result = EventUtils.getEdgeConfiguration(new HashMap<>());
+
+		assertEquals(false, result.containsKey("edge.batching.enabled"));
+	}
+
+	@Test
+	public void testGetEdgeConfiguration_eventNameAllowlist_presentInSharedState_bundledConfigIgnored() {
+		mockBundledBatchingConfigStatic
+			.when(EdgeBundledBatchingConfig::get)
+			.thenReturn(Collections.singletonMap("edge.batching.eventNameAllowlist", Arrays.asList("BundledEvent")));
+
+		Map<String, Object> result = EventUtils.getEdgeConfiguration(
+			new HashMap<String, Object>() {
+				{
+					put("edge.batching.eventNameAllowlist", Arrays.asList("SharedStateEvent"));
+				}
+			}
+		);
+
+		assertEquals(Arrays.asList("SharedStateEvent"), result.get("edge.batching.eventNameAllowlist"));
+	}
+
+	@Test
+	public void testGetEdgeConfiguration_eventNameAllowlist_absentFromSharedState_usesBundledConfig() {
+		mockBundledBatchingConfigStatic
+			.when(EdgeBundledBatchingConfig::get)
+			.thenReturn(Collections.singletonMap("edge.batching.eventNameAllowlist", Arrays.asList("BundledEvent")));
+
+		Map<String, Object> result = EventUtils.getEdgeConfiguration(new HashMap<>());
+
+		assertEquals(Arrays.asList("BundledEvent"), result.get("edge.batching.eventNameAllowlist"));
+	}
+
+	@Test
+	public void testGetEdgeConfiguration_eventNameAllowlist_absentFromBoth_keyNotInResult() {
+		Map<String, Object> result = EventUtils.getEdgeConfiguration(new HashMap<>());
+
+		assertEquals(false, result.containsKey("edge.batching.eventNameAllowlist"));
 	}
 }

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/EventUtilsTests.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/EventUtilsTests.java
@@ -287,4 +287,39 @@ public class EventUtilsTests {
 
 		assertEquals(false, result.containsKey("edge.batching.eventNameAllowlist"));
 	}
+
+	@Test
+	public void testGetEdgeConfiguration_maxBatchSize_presentInSharedState_bundledConfigIgnored() {
+		mockBundledBatchingConfigStatic
+			.when(EdgeBundledBatchingConfig::get)
+			.thenReturn(Collections.singletonMap("edge.batching.maxBatchSize", 5));
+
+		Map<String, Object> result = EventUtils.getEdgeConfiguration(
+			new HashMap<String, Object>() {
+				{
+					put("edge.batching.maxBatchSize", 25);
+				}
+			}
+		);
+
+		assertEquals(25, result.get("edge.batching.maxBatchSize"));
+	}
+
+	@Test
+	public void testGetEdgeConfiguration_maxBatchSize_absentFromSharedState_usesBundledConfig() {
+		mockBundledBatchingConfigStatic
+			.when(EdgeBundledBatchingConfig::get)
+			.thenReturn(Collections.singletonMap("edge.batching.maxBatchSize", 25));
+
+		Map<String, Object> result = EventUtils.getEdgeConfiguration(new HashMap<>());
+
+		assertEquals(25, result.get("edge.batching.maxBatchSize"));
+	}
+
+	@Test
+	public void testGetEdgeConfiguration_maxBatchSize_absentFromBoth_keyNotInResult() {
+		Map<String, Object> result = EventUtils.getEdgeConfiguration(new HashMap<>());
+
+		assertEquals(false, result.containsKey("edge.batching.maxBatchSize"));
+	}
 }

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
@@ -145,8 +145,6 @@ public class NetworkResponseHandlerTest {
 	@After
 	public void tearDown() {
 		mockCore.close();
-		// Reset the co-located behaviour switch so a test that flips it can't leak into others.
-		NetworkResponseHandler.earlyPerEventCompletionEnabled = true;
 	}
 
 	@Test
@@ -2118,7 +2116,7 @@ public class NetworkResponseHandlerTest {
 	}
 
 	// -------------------------------------------------------------------------
-	// Early per-event completion (index-advance) — NetworkResponseHandler.earlyPerEventCompletionEnabled
+	// Early per-event completion (index-advance)
 	// -------------------------------------------------------------------------
 
 	/** A single streamed fragment carrying one indexed, non-global handle for {@code eventIndex}. */
@@ -2364,32 +2362,4 @@ public class NetworkResponseHandlerTest {
 		assertEquals(e2.getUniqueIdentifier(), all.get(2).getParentID());
 	}
 
-	@Test
-	public void testEarlyCompletionDisabled_completesAllAtStreamClose_legacyParity() {
-		NetworkResponseHandler.earlyPerEventCompletionEnabled = false; // reset in tearDown
-
-		final String requestId = "req-legacy";
-		final Event e0 = completionEvent("e0");
-		final Event e1 = completionEvent("e1");
-		networkResponseHandler.addWaitingEvents(
-			requestId,
-			new ArrayList<Event>() {
-				{
-					add(e0);
-					add(e1);
-				}
-			}
-		);
-
-		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(0), requestId);
-		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(1), requestId);
-		// disabled → nothing completes early even though a higher index was seen
-		assertEquals(0, capturedContentCompleteEvents().size());
-
-		networkResponseHandler.processResponseOnComplete(requestId);
-		List<Event> completes = capturedContentCompleteEvents();
-		assertEquals(2, completes.size());
-		assertEquals(e0.getUniqueIdentifier(), completes.get(0).getParentID());
-		assertEquals(e1.getUniqueIdentifier(), completes.get(1).getParentID());
-	}
 }

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -144,6 +145,8 @@ public class NetworkResponseHandlerTest {
 	@After
 	public void tearDown() {
 		mockCore.close();
+		// Reset the co-located behaviour switch so a test that flips it can't leak into others.
+		NetworkResponseHandler.earlyPerEventCompletionEnabled = true;
 	}
 
 	@Test
@@ -2112,5 +2115,281 @@ public class NetworkResponseHandlerTest {
 		assertEquals("state:store", dispatched.getSource());
 		// Broadcast has no parent
 		assertNull(dispatched.getParentID());
+	}
+
+	// -------------------------------------------------------------------------
+	// Early per-event completion (index-advance) — NetworkResponseHandler.earlyPerEventCompletionEnabled
+	// -------------------------------------------------------------------------
+
+	/** A single streamed fragment carrying one indexed, non-global handle for {@code eventIndex}. */
+	private static String indexedHandleFragment(final int eventIndex) {
+		return (
+			"{\n" +
+			"  \"handle\": [\n" +
+			"    { \"type\": \"pairedeventexample\", \"eventIndex\": " +
+			eventIndex +
+			", \"payload\": [ { \"id\": \"p" +
+			eventIndex +
+			"\" } ] }\n" +
+			"  ]\n" +
+			"}"
+		);
+	}
+
+	/** A single streamed fragment carrying a global (no eventIndex) state:store handle. */
+	private static String globalStateStoreFragment() {
+		return (
+			"{\n" +
+			"  \"handle\": [\n" +
+			"    { \"type\": \"state:store\", \"payload\": [ { \"key\": \"k\", \"value\": \"v\", \"maxAge\": 1 } ] }\n" +
+			"  ]\n" +
+			"}"
+		);
+	}
+
+	private Event completionEvent(final String name) {
+		return new Event.Builder(name, "testType", "testSource").setEventData(requestSendCompletionTrueEventData).build();
+	}
+
+	/** Captures all dispatched events so far and returns only the CONTENT_COMPLETE ones, in order. */
+	private List<Event> capturedContentCompleteEvents() {
+		ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+		mockCore.verify(() -> MobileCore.dispatchEvent(captor.capture()), atLeast(0));
+		List<Event> completes = new ArrayList<>();
+		for (Event e : captor.getAllValues()) {
+			if (EVENT_SOURCE_CONTENT_COMPLETE.equals(e.getSource())) {
+				completes.add(e);
+			}
+		}
+		return completes;
+	}
+
+	@Test
+	public void testEarlyCompletion_multiEventStream_completesEachEventWhenNextIndexArrives() {
+		final String requestId = "req-early";
+		final Event e0 = completionEvent("e0");
+		final Event e1 = completionEvent("e1");
+		final Event e2 = completionEvent("e2");
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(e0);
+					add(e1);
+					add(e2);
+				}
+			}
+		);
+
+		// index 0 fragment: nothing completes yet (no higher index seen)
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(0), requestId);
+		assertEquals(0, capturedContentCompleteEvents().size());
+
+		// index 1 fragment: event 0 is now known complete
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(1), requestId);
+		List<Event> after1 = capturedContentCompleteEvents();
+		assertEquals(1, after1.size());
+		assertEquals(e0.getUniqueIdentifier(), after1.get(0).getParentID());
+
+		// index 2 fragment: event 1 now completes
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(2), requestId);
+		List<Event> after2 = capturedContentCompleteEvents();
+		assertEquals(2, after2.size());
+		assertEquals(e1.getUniqueIdentifier(), after2.get(1).getParentID());
+
+		// stream close: the last event (index 2) completes
+		networkResponseHandler.processResponseOnComplete(requestId);
+		List<Event> afterComplete = capturedContentCompleteEvents();
+		assertEquals(3, afterComplete.size());
+		assertEquals(e2.getUniqueIdentifier(), afterComplete.get(2).getParentID());
+	}
+
+	@Test
+	public void testEarlyCompletion_completionFiresBeforeNextIndexHandleDispatch() {
+		// A completing event's downstream listeners (e.g. a caller merging accumulated response data
+		// into its own cache on completion) must never observe a higher-indexed sibling's handle data
+		// that arrived in the same response — so completion(N) must be dispatched strictly before
+		// index N+1's own handle is dispatched, not after.
+		final String requestId = "req-order";
+		final Event e0 = completionEvent("e0");
+		final Event e1 = completionEvent("e1");
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(e0);
+					add(e1);
+				}
+			}
+		);
+
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(0), requestId);
+
+		ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+		mockCore.reset();
+		// index 1 fragment, in the SAME processResponseOnSuccess call: this must first complete
+		// event 0, THEN dispatch index 1's own handle — not the other way around.
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(1), requestId);
+		mockCore.verify(() -> MobileCore.dispatchEvent(captor.capture()), atLeast(1));
+
+		int completionIndex = -1;
+		int handle1Index = -1;
+		List<Event> dispatched = captor.getAllValues();
+		for (int i = 0; i < dispatched.size(); i++) {
+			Event e = dispatched.get(i);
+			if (EVENT_SOURCE_CONTENT_COMPLETE.equals(e.getSource()) && e0.getUniqueIdentifier().equals(e.getParentID())) {
+				completionIndex = i;
+			} else if ("pairedeventexample".equals(e.getSource())) {
+				handle1Index = i;
+			}
+		}
+
+		assertTrue("event 0's completion must be dispatched", completionIndex >= 0);
+		assertTrue("index 1's handle must be dispatched", handle1Index >= 0);
+		assertTrue(
+			"completion for event 0 must be dispatched before index 1's handle, so a completion listener never observes index 1's data",
+			completionIndex < handle1Index
+		);
+	}
+
+	@Test
+	public void testEarlyCompletion_zeroHandleMiddleEvent_completesOnIndexAdvance() {
+		final String requestId = "req-zero";
+		final Event e0 = completionEvent("e0");
+		final Event e1 = completionEvent("e1"); // will receive no handle of its own
+		final Event e2 = completionEvent("e2");
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(e0);
+					add(e1);
+					add(e2);
+				}
+			}
+		);
+
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(0), requestId);
+		assertEquals(0, capturedContentCompleteEvents().size());
+
+		// jump straight to index 2 (event 1 produced nothing) → events 0 AND 1 complete
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(2), requestId);
+		List<Event> completes = capturedContentCompleteEvents();
+		assertEquals(2, completes.size());
+		assertEquals(e0.getUniqueIdentifier(), completes.get(0).getParentID());
+		assertEquals(e1.getUniqueIdentifier(), completes.get(1).getParentID());
+
+		networkResponseHandler.processResponseOnComplete(requestId);
+		assertEquals(3, capturedContentCompleteEvents().size());
+	}
+
+	@Test
+	public void testEarlyCompletion_globalHandle_doesNotAdvanceCompletion() {
+		final String requestId = "req-global";
+		final Event e0 = completionEvent("e0");
+		final Event e1 = completionEvent("e1");
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(e0);
+					add(e1);
+				}
+			}
+		);
+
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(0), requestId);
+		// a global (no-eventIndex) handle must NOT advance completion
+		networkResponseHandler.processResponseOnSuccess(globalStateStoreFragment(), requestId);
+		assertEquals(0, capturedContentCompleteEvents().size());
+
+		networkResponseHandler.processResponseOnComplete(requestId);
+		assertEquals(2, capturedContentCompleteEvents().size());
+	}
+
+	@Test
+	public void testEarlyCompletion_batchOfOne_completesOnlyAtStreamClose() {
+		final String requestId = "req-single";
+		final Event e0 = completionEvent("e0");
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(e0);
+				}
+			}
+		);
+
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(0), requestId);
+		// only index 0 exists → no early completion, identical to legacy
+		assertEquals(0, capturedContentCompleteEvents().size());
+
+		networkResponseHandler.processResponseOnComplete(requestId);
+		List<Event> completes = capturedContentCompleteEvents();
+		assertEquals(1, completes.size());
+		assertEquals(e0.getUniqueIdentifier(), completes.get(0).getParentID());
+	}
+
+	@Test
+	public void testEarlyCompletion_outOfOrderLowerIndex_doesNotDoubleComplete() {
+		final String requestId = "req-anomaly";
+		final Event e0 = completionEvent("e0");
+		final Event e1 = completionEvent("e1");
+		final Event e2 = completionEvent("e2");
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(e0);
+					add(e1);
+					add(e2);
+				}
+			}
+		);
+
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(0), requestId);
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(2), requestId); // completes e0, e1
+		assertEquals(2, capturedContentCompleteEvents().size());
+
+		// anomaly: index 1 arrives after events through index 1 were already completed → no re-completion
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(1), requestId);
+		assertEquals(2, capturedContentCompleteEvents().size());
+
+		networkResponseHandler.processResponseOnComplete(requestId);
+		List<Event> all = capturedContentCompleteEvents();
+		assertEquals(3, all.size());
+		// each event completed exactly once, in index order
+		assertEquals(e0.getUniqueIdentifier(), all.get(0).getParentID());
+		assertEquals(e1.getUniqueIdentifier(), all.get(1).getParentID());
+		assertEquals(e2.getUniqueIdentifier(), all.get(2).getParentID());
+	}
+
+	@Test
+	public void testEarlyCompletionDisabled_completesAllAtStreamClose_legacyParity() {
+		NetworkResponseHandler.earlyPerEventCompletionEnabled = false; // reset in tearDown
+
+		final String requestId = "req-legacy";
+		final Event e0 = completionEvent("e0");
+		final Event e1 = completionEvent("e1");
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(e0);
+					add(e1);
+				}
+			}
+		);
+
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(0), requestId);
+		networkResponseHandler.processResponseOnSuccess(indexedHandleFragment(1), requestId);
+		// disabled → nothing completes early even though a higher index was seen
+		assertEquals(0, capturedContentCompleteEvents().size());
+
+		networkResponseHandler.processResponseOnComplete(requestId);
+		List<Event> completes = capturedContentCompleteEvents();
+		assertEquals(2, completes.size());
+		assertEquals(e0.getUniqueIdentifier(), completes.get(0).getParentID());
+		assertEquals(e1.getUniqueIdentifier(), completes.get(1).getParentID());
 	}
 }

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
@@ -828,6 +828,10 @@ public class NetworkResponseHandlerTest {
 		assertNotNull(returnedEvent);
 		assertTrue(EVENT_TYPE_EDGE.equalsIgnoreCase(returnedEvent.getType()));
 		assertTrue("state:store".equalsIgnoreCase(returnedEvent.getSource()));
+		// Batch routing policy: state:store carries no eventIndex and is a global (session-scoped)
+		// handle. In a multi-event request it is broadcast with a null parentId rather than being
+		// mis-attributed to event[0], so no requestEventId is present. The store side-effect is still
+		// persisted globally (handleStoreEventHandle runs before routing).
 		String expectedEventData =
 			"{\n" +
 			"  \"type\": \"state:store\",\n" +
@@ -838,10 +842,7 @@ public class NetworkResponseHandlerTest {
 			"      \"maxAge\": 15552000\n" +
 			"    }\n" +
 			"  ],\n" +
-			"  \"requestId\": \"123\",\n" +
-			"  \"requestEventId\": \"" +
-			requestEvent1.getUniqueIdentifier() +
-			"\"\n" +
+			"  \"requestId\": \"123\"\n" +
 			"}";
 		JSONAsserts.assertEquals(expectedEventData, returnedEvent.getEventData());
 
@@ -849,6 +850,7 @@ public class NetworkResponseHandlerTest {
 		assertNotNull(returnedEvent);
 		assertTrue(EVENT_TYPE_EDGE.equalsIgnoreCase(returnedEvent.getType()));
 		assertTrue("pairedeventexample".equalsIgnoreCase(returnedEvent.getSource()));
+		// Indexed handle (eventIndex 1) is still attributed to its specific event.
 		expectedEventData =
 			"{\n" +
 			"  \"type\": \"pairedeventexample\",\n" +
@@ -1235,19 +1237,11 @@ public class NetworkResponseHandlerTest {
 		latch.await(100, TimeUnit.MILLISECONDS);
 		latch.await(100, TimeUnit.MILLISECONDS);
 
-		assertEquals(1, receivedData1.size());
-		String expectedEventData1 =
-			"{\n" +
-			"  \"payload\": [\n" +
-			"    {\n" +
-			"      \"key\": \"s_ecid\",\n" +
-			"      \"value\": \"MCMID|29068398647607325310376254630528178721\",\n" +
-			"      \"maxAge\": 15552000\n" +
-			"    }\n" +
-			"  ],\n" +
-			"  \"type\": \"state:store\"\n" +
-			"}";
-		JSONAsserts.assertEquals(expectedEventData1, receivedData1.get(0).toMap());
+		// state:store carries no eventIndex and is a global handle: in a multi-event request it is
+		// broadcast (null parentId) and not accumulated against any single event's callback, so
+		// event1 (which had no indexed handle of its own) receives zero handles. The store payload
+		// is still persisted globally.
+		assertEquals(0, receivedData1.size());
 
 		assertEquals(1, receivedData2.size());
 		String expectedEventData2 =
@@ -1996,5 +1990,127 @@ public class NetworkResponseHandlerTest {
 			assertEquals(parentEventIds[i], returnedEvent.getParentID());
 			assertEquals(parentEventIds[i], returnedEvent.getResponseID());
 		}
+	}
+
+	// -------------------------------------------------------------------------
+	// WI-2: collapsed no-index error routing — fan-out to all waiting events
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void testDispatchEventErrors_noIndex_batchOfTwo_fanOutToBothWaitingEvents() {
+		// A no-index error for a batch of 2 must produce one ERROR_RESPONSE_CONTENT per waiting event.
+		final String jsonError =
+			"{\n" +
+			"  \"requestId\": \"batch-req-123\",\n" +
+			"  \"errors\": [\n" +
+			"    {\n" +
+			"      \"status\": 503,\n" +
+			"      \"type\": \"https://ns.adobe.com/aep/errors/EXEG-0201-503\",\n" +
+			"      \"title\": \"Service unavailable\"\n" +
+			"    }\n" +
+			"  ]\n" +
+			"}";
+
+		final String requestId = "batch-req-id";
+		final Event event1 = new Event.Builder("e1", "testType", "testSource").build();
+		final Event event2 = new Event.Builder("e2", "testType", "testSource").build();
+
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(event1);
+					add(event2);
+				}
+			}
+		);
+		networkResponseHandler.processResponseOnError(jsonError, requestId);
+
+		// 2 error events dispatched — one per waiting event
+		ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+		mockCore.verify(() -> MobileCore.dispatchEvent(captor.capture()), times(2));
+
+		List<Event> dispatched = captor.getAllValues();
+		assertEquals(2, dispatched.size());
+
+		// Both events are on the error channel
+		for (Event e : dispatched) {
+			assertEquals(EVENT_SOURCE_EXTENSION_ERROR_RESPONSE_CONTENT, e.getSource());
+		}
+
+		// Each event is chained to its own originating request event
+		assertEquals(event1.getUniqueIdentifier(), dispatched.get(0).getParentID());
+		assertEquals(event2.getUniqueIdentifier(), dispatched.get(1).getParentID());
+	}
+
+	@Test
+	public void testDispatchEventErrors_noIndex_singleWaitingEvent_routesToThatEvent() {
+		// WI-2 collapsed path: a single waiting event is N==1, the loop naturally yields event[0].
+		final String jsonError =
+			"{\n" +
+			"  \"requestId\": \"req-single\",\n" +
+			"  \"errors\": [\n" +
+			"    {\n" +
+			"      \"status\": 503,\n" +
+			"      \"type\": \"https://ns.adobe.com/aep/errors/EXEG-0201-503\",\n" +
+			"      \"title\": \"Service unavailable\"\n" +
+			"    }\n" +
+			"  ]\n" +
+			"}";
+
+		final String requestId = "req-single";
+		final Event event1 = new Event.Builder("e1", "testType", "testSource").build();
+
+		networkResponseHandler.addWaitingEvents(requestId, new ArrayList<Event>() {{ add(event1); }});
+		networkResponseHandler.processResponseOnError(jsonError, requestId);
+
+		// Exactly 1 error event, chained to event1
+		ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+		mockCore.verify(() -> MobileCore.dispatchEvent(captor.capture()), times(1));
+
+		Event dispatched = captor.getValue();
+		assertEquals(EVENT_SOURCE_EXTENSION_ERROR_RESPONSE_CONTENT, dispatched.getSource());
+		assertEquals(event1.getUniqueIdentifier(), dispatched.getParentID());
+	}
+
+	@Test
+	public void testProcessResponseOnSuccess_stateStoreHandle_noIndex_batchOfTwo_broadcastsOnce() {
+		// Global handle (state:store) with no eventIndex must be broadcast as exactly ONE event
+		// with null parentId regardless of batch size (locked decision 1).
+		final String jsonResponse =
+			"{\n" +
+			"  \"requestId\": \"batch-state-req\",\n" +
+			"  \"handle\": [\n" +
+			"    {\n" +
+			"      \"type\": \"state:store\",\n" +
+			"      \"payload\": [{\"key\": \"kndctr_org_cluster\", \"value\": \"va6\", \"maxAge\": 1800}]\n" +
+			"    }\n" +
+			"  ]\n" +
+			"}";
+
+		final String requestId = "batch-state-req";
+		final Event event1 = new Event.Builder("e1", "testType", "testSource").build();
+		final Event event2 = new Event.Builder("e2", "testType", "testSource").build();
+
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(event1);
+					add(event2);
+				}
+			}
+		);
+		networkResponseHandler.processResponseOnSuccess(jsonResponse, requestId);
+
+		// Exactly one RESPONSE_CONTENT event (the broadcast), NOT two
+		ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+		mockCore.verify(() -> MobileCore.dispatchEvent(captor.capture()), times(1));
+
+		Event dispatched = captor.getValue();
+		// state:store events are dispatched using the handle type as the event source (see dispatchEventResponse)
+		assertEquals("state:store", dispatched.getSource());
+		// Broadcast has no parent
+		assertNull(dispatched.getParentID());
 	}
 }

--- a/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
+++ b/code/edge/src/test/java/com/adobe/marketing/mobile/NetworkResponseHandlerTest.java
@@ -2062,7 +2062,14 @@ public class NetworkResponseHandlerTest {
 		final String requestId = "req-single";
 		final Event event1 = new Event.Builder("e1", "testType", "testSource").build();
 
-		networkResponseHandler.addWaitingEvents(requestId, new ArrayList<Event>() {{ add(event1); }});
+		networkResponseHandler.addWaitingEvents(
+			requestId,
+			new ArrayList<Event>() {
+				{
+					add(event1);
+				}
+			}
+		);
 		networkResponseHandler.processResponseOnError(jsonError, requestId);
 
 		// Exactly 1 error event, chained to event1
@@ -2146,7 +2153,9 @@ public class NetworkResponseHandlerTest {
 	}
 
 	private Event completionEvent(final String name) {
-		return new Event.Builder(name, "testType", "testSource").setEventData(requestSendCompletionTrueEventData).build();
+		return new Event.Builder(name, "testType", "testSource")
+			.setEventData(requestSendCompletionTrueEventData)
+			.build();
 	}
 
 	/** Captures all dispatched events so far and returns only the CONTENT_COMPLETE ones, in order. */
@@ -2235,7 +2244,9 @@ public class NetworkResponseHandlerTest {
 		List<Event> dispatched = captor.getAllValues();
 		for (int i = 0; i < dispatched.size(); i++) {
 			Event e = dispatched.get(i);
-			if (EVENT_SOURCE_CONTENT_COMPLETE.equals(e.getSource()) && e0.getUniqueIdentifier().equals(e.getParentID())) {
+			if (
+				EVENT_SOURCE_CONTENT_COMPLETE.equals(e.getSource()) && e0.getUniqueIdentifier().equals(e.getParentID())
+			) {
 				completionIndex = i;
 			} else if ("pairedeventexample".equals(e.getSource())) {
 				handle1Index = i;
@@ -2361,5 +2372,4 @@ public class NetworkResponseHandlerTest {
 		assertEquals(e1.getUniqueIdentifier(), all.get(1).getParentID());
 		assertEquals(e2.getUniqueIdentifier(), all.get(2).getParentID());
 	}
-
 }

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -16,10 +16,10 @@ org.gradle.configureondemand=false
 org.gradle.caching=true
 
 moduleName=edge
-moduleVersion=3.0.2
-mavenCoreVersion=3.3.0
-mavenEdgeIdentityVersion=3.0.1
-mavenEdgeConsentVersion=3.0.0
+moduleVersion=3.1.2
+mavenCoreVersion=3.8.0
+mavenEdgeIdentityVersion=3.1.0
+mavenEdgeConsentVersion=3.0.3
 mavenTestUtilsVersion=3.0.0
 mavenRepoName=AdobeMobileEdgeSdk
 mavenRepoDescription=Adobe Experience Platform Edge extension for the Adobe Experience Platform Mobile SDK

--- a/code/upstream-integration-tests/src/androidTest/java/com/adobe/marketing/mobile/edge/integration/UpstreamIntegrationTests.kt
+++ b/code/upstream-integration-tests/src/androidTest/java/com/adobe/marketing/mobile/edge/integration/UpstreamIntegrationTests.kt
@@ -410,7 +410,7 @@ class UpstreamIntegrationTests {
             stateStoreEvent.eventData,
             ValueExactMatch("payload[*].key"),
             // Used to strictly validate `payload` and elements under it have same count as expected
-            CollectionEqualCount(Subtree, "payload") 
+            CollectionEqualCount(Subtree, "payload")
         )
     }
 

--- a/code/upstream-integration-tests/src/androidTest/java/com/adobe/marketing/mobile/edge/integration/util/IntegrationTestConstants.kt
+++ b/code/upstream-integration-tests/src/androidTest/java/com/adobe/marketing/mobile/edge/integration/util/IntegrationTestConstants.kt
@@ -1,3 +1,14 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
 package com.adobe.marketing.mobile.edge.integration.util
 
 internal object IntegrationTestConstants {

--- a/code/upstream-integration-tests/src/androidTest/java/com/adobe/marketing/mobile/edge/integration/util/TestSetupHelper.kt
+++ b/code/upstream-integration-tests/src/androidTest/java/com/adobe/marketing/mobile/edge/integration/util/TestSetupHelper.kt
@@ -69,8 +69,10 @@ object TestSetupHelper {
         val sharedState = TestHelper.getSharedStateFor(IntegrationTestConstants.ExtensionName.CONFIGURATION, 10_000)
         val edgeDomain = (sharedState?.get(IntegrationTestConstants.ConfigurationKey.EDGE_DOMAIN) as? String)
             ?: run {
-                println("Edge domain could not be fetched from the configuration shared state, or was invalid. " +
-                        "Using default Edge domain: ${IntegrationTestConstants.NetworkKeys.DEFAULT_EDGE_DOMAIN}")
+                println(
+                    "Edge domain could not be fetched from the configuration shared state, or was invalid. " +
+                        "Using default Edge domain: ${IntegrationTestConstants.NetworkKeys.DEFAULT_EDGE_DOMAIN}"
+                )
                 IntegrationTestConstants.NetworkKeys.DEFAULT_EDGE_DOMAIN
             }
         return if (locationHint.isNullOrEmpty()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## Summary

Adds Experience Event batching to the Edge extension: consecutive `ExperienceEvent`s that share a snapshotted request config can now be coalesced into a single Edge Network request instead of one request per event, reducing network overhead for high-volume event sources (e.g. Optimize/Target tracking, Messaging interactions). Batching is **opt-in and off by default** — SDKs that never enable it see byte-for-byte identical behavior to today.

Also adds a per-event error callback: `EdgeCallbackWithError` / `EdgeEventError`, delivered via a new `Edge.sendEvent(ExperienceEvent, EdgeCallbackWithError)` overload, so callers can receive Edge Network errors for their specific event, not just success handles.

## Configuration

Two new keys, both read from the `Configuration` shared state:

- `edge.batching.enabled` (bool, default `false`)
- `edge.batching.eventNameAllowlist` (list of event names) — batching is opt-in per event name; an event only batches if its name is explicitly allowlisted, even when `enabled` is `true`.

Both keys also support a first-launch fallback: an optional `adb_edgeBatchingConfig.json` bundled in the app's assets (`EdgeBundledBatchingConfig`), consulted per-key only when that key is absent from the Configuration shared state. Anything set via `MobileCore.updateConfiguration()` or a remote/Launch config always wins over the bundled file for that key.

## How batching works

- **Queue**: `EdgeBatchingHitQueue` replaces `PersistentHitQueue` as the Edge extension's hit queue. Each cycle peeks a window sized from the head entity's *snapshotted* config: 1 if batching is disabled (identical to today), or `min(queueDepth, MAX_BATCH_SIZE=10)` if enabled.
- **Eligibility**: `EdgeHitProcessor.processBatch` walks the peeked window and only folds in *consecutive* entities that are all ExperienceEvents, all on the allowlist, and all share the head's config (a batched request can only carry one datastream ID/override — an entity with a different config truncates the run and becomes its own head on a later cycle). Hitting a Consent/Reset event, a non-allowlisted name, or a config mismatch stops the run; anything before that point still batches.
- **400 handling**: a 400 on a real (N>1) batch means nothing was ingested. Rather than resend the whole batch, the processor signals `BatchOutcome.explode(N)` and the queue drains those N entities **one at a time** through the exact same single-event send path non-batching builds already use, retrying a recoverable failure in place (never skipping it). This is not the same as before batching existed: on 400/other unrecoverable codes, `isBatchRequest` on `EdgeNetworkService.doRequest` gates whether the network layer classifies a 400 as explodable — only real batches take that branch; a single event's 400 falls through to the identical unrecoverable-error handling as pre-batching code.
- **Per-event completion**: `NetworkResponseHandler` now completes each event in a batch as soon as a higher-indexed response fragment arrives, instead of waiting for the whole request's stream to close — so an early event in a batch doesn't wait on a later one. A handle/error with no `eventIndex` is treated as request-scoped: for `state:store`/`locationHint:result` (session-global side effects) it's broadcast to all waiting events; for errors, a root-level error is treated as the whole batch failing, so it fans out to every waiting event's callback. Single events are unaffected — with one waiting event, this degrades to exactly today's behavior.

## Notable internal refactors (behavior-preserving)

- `BatchOutcome` is a small `Kind` (`DONE`/`RETRY`/`EXPLODE`) + single `int value`, rather than three independent counters where only one was ever meaningful.
- `RetryResult.shouldRetry` is now computed from `NetworkRequestOutcome` rather than stored redundantly.
- The batch and single-event request-build/send paths share `buildExperienceEventHit`/`sendEdgeHit` instead of duplicating logic.
- Non-batching log messages/format are preserved as-is (including event IDs) versus `main`.

## Compatibility

- Batching off (default): queue window is always 1, `processBatch` routes every entity through the pre-existing single-event path, and 400/error/retry handling is unchanged from before this feature.
- New public API only adds: `EdgeCallbackWithError`, `EdgeEventError`, and the new `Edge.sendEvent` overload — no existing signatures changed.

## Testing

- **Unit**: 473 tests across `EdgeHitProcessor`, `EdgeBatchingHitQueue`, `NetworkResponseHandler`, `EdgeNetworkService`, `EventUtils`, `EdgeBundledBatchingConfig`, `CompletionCallbacksManager` — batch formation, config-mismatch truncation, 400/explode/drain (including retry-without-skip), per-event completion ordering, global-handle/error broadcast, and bundled-config precedence.
- **Functional** (`androidTest`, on-device/emulator): new `EdgeBatchingFunctionalTests` (non-batching regression, allowlist gating, real batch coalescing, per-event completion under a server error) plus updates to `NetworkResponseHandlerFunctionalTests` and `CompletionHandlerFunctionalTests` for the new global-handle/error-fanout semantics and the `EdgeCallbackWithError` path.
- **On-device, real Edge Network traffic** (Optimize test app): verified real batch formation (multiple tracking events coalesced into one request with correct per-index handle attribution), global no-index handles (`state:store`, `locationHint:result`) broadcasting correctly in a real multi-event response, the non-batching path producing one request per event with batching off, and a real per-event error response — with no crashes, warnings, or response-ordering violations across all scenarios.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
